### PR TITLE
Remove placeholder Google links

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,15 @@ This catalogue is maintained by the AgentOps initiative and is updated regularly
 
 ## TOC
 
-\*(\#why-agentops-is-different)
-\*(\#fast-start-picks-curated-for-newcomers)
-\*(\#the-agentops-top-50-ai-agent-repositories)
-
-  * [💎 Honourable Mentions / Niche & Novel Gems](https://www.google.com/search?q=%23honourable-mentions--niche--novel-gems)
-    \*(https://www.google.com/search?q=%23our-methodology--scoring-explained)
-    \*(\#category-definitions)
-  * [🔄 Changelog](https://www.google.com/search?q=%23changelog)
-  * [🤝 How to Contribute](https://www.google.com/search?q=%23how-to-contribute)
-  * [📜 License](https://www.google.com/search?q=%23license)
+* [✨ Why AgentOps is Different](#why-agentops-is-different)
+* [🚀 Fast-Start Picks (Curated for Newcomers)](#fast-start-picks-curated-for-newcomers)
+* [🏆 The AgentOps Top 50: AI Agent Repositories](#the-agentops-top-50-ai-agent-repositories)
+  * [💎 Honourable Mentions / Niche & Novel Gems](#honourable-mentions--niche--novel-gems)
+    * [🔬 Our Methodology & Scoring Explained](#our-methodology--scoring-explained)
+    * [🏷️ Category Definitions](#category-definitions)
+  * [🔄 Changelog](#changelog)
+  * [🤝 How to Contribute](#how-to-contribute)
+  * [📜 License](#license)
 
 -----
 
@@ -54,11 +53,11 @@ This catalogue is maintained by the AgentOps initiative and is updated regularly
 
 In the fast-moving world of Agentic-AI, finding high-quality, actively maintained, and truly impactful frameworks can be a pain. Many lists are subjective or just track stars. AgentOps cuts through the noise with an analytical approach:
 
-  * **Systematic Scoring:** Every repo gets crunched through our [transparent scoring formula](https://www.google.com/search?q=%23our-methodology--scoring-explained). We look at real signals: community traction (stars [1, 2]), development activity (commit recency [1, 2]), maintenance health (issue management [3, 4]), documentation quality, license permissiveness [1, 2], and ecosystem integration.[1, 5] No black boxes.
-  * **Focus on Builder Tools:** We spotlight frameworks, toolkits, and platforms that *actually help you build and orchestrate AI agents*. Check our [scope definition](https://www.google.com/search?q=./docs/methodology.md) for the nitty-gritty.
-  * **Relentlessly Fresh:** Data gets a refresh monthly (or sooner if big shifts happen). Stale lists suck. Our [Changelog](https://www.google.com/search?q=./CHANGELOG.md) keeps score.
+  * **Systematic Scoring:** Every repo gets crunched through our [transparent scoring formula](#our-methodology--scoring-explained). We look at real signals: community traction (stars [1, 2]), development activity (commit recency [1, 2]), maintenance health (issue management [3, 4]), documentation quality, license permissiveness [1, 2], and ecosystem integration.[1, 5] No black boxes.
+  * **Focus on Builder Tools:** We spotlight frameworks, toolkits, and platforms that *actually help you build and orchestrate AI agents*. Check our [scope definition](./docs/methodology.md) for the nitty-gritty.
+  * **Relentlessly Fresh:** Data gets a refresh monthly (or sooner if big shifts happen). Stale lists suck. Our [Changelog](./CHANGELOG.md) keeps score.
   * **Automated Vigilance:** A GitHub Action keeps an eye on things weekly, flagging big score or rank changes for review. This keeps the "freshness" promise real.
-  * **Open & Transparent:** Our entire [methodology](https://www.google.com/search?q=./docs/methodology.md) – data sources, scoring weights, the lot – is out in the open. Trust through transparency.
+  * **Open & Transparent:** Our entire [methodology](./docs/methodology.md) – data sources, scoring weights, the lot – is out in the open. Trust through transparency.
 
 AgentOps is built to be a reliable, data-driven launchpad for your next Agentic-AI project.
 
@@ -96,7 +95,7 @@ The definitive list of Agentic-AI repositories, ranked by the AgentOps Score. Th
 | 10 | [e2b-dev/e2b](https://github.com/e2b-dev/e2b) | 8.6k | 2025-06-13 | 81 | 🛠️ DevTools | Secure open source cloud runtime for AI apps & AI agents. [16] |
 |... |... |... |... |... |... |... |
 
-*➡️ Dig into how these scores are cooked up in our [Methodology section](https://www.google.com/search?q=%23our-methodology--scoring-explained) and the [full recipe in /docs/methodology.md](https://www.google.com/search?q=./docs/methodology.md).*
+*➡️ Dig into how these scores are cooked up in our [Methodology section](#our-methodology--scoring-explained) and the [full recipe in /docs/methodology.md](./docs/methodology.md).*
 
 -----
 
@@ -112,6 +111,7 @@ Beyond the top-ranked, these projects are cooking up unique ideas, serving speci
 
 -----
 
+<a id="our-methodology--scoring-explained"></a>
 \<details\>
 \<summary\>🔬 Our Methodology & Scoring Explained (Click to Expand)\</summary\>
 
@@ -120,7 +120,7 @@ AgentOps believes in full transparency. Here’s the lowdown on how we find, vet
 The core AgentOps Scoring Formula:
 `Score = 0.35*log2(stars+1) + 0.20*recency_factor + 0.15*issue_health + 0.15*doc_completeness + 0.10*license_freedom + 0.05*ecosystem_integration`\<sup\>†\</sup\>
 
-\<sup\>†\</sup\> *Weights are reviewed and potentially tuned quarterly. Full math and reasoning in [`/docs/methodology.md`](https://www.google.com/search?q=./docs/methodology.md).*
+\<sup\>†\</sup\> *Weights are reviewed and potentially tuned quarterly. Full math and reasoning in [`/docs/methodology.md`](./docs/methodology.md).*
 
 **Quick Look at Components:**
 
@@ -129,7 +129,7 @@ The core AgentOps Scoring Formula:
   * **Quality & Activity Scoring:** The formula balances community buzz, dev activity, maintenance, docs, license, and how well it plays with others.
   * **De-duplication & Categorisation:** Forks usually get skipped unless they’re their own thing now. Repos get bucketed by their main gig.
 
-For the full, unabridged version, see **[./docs/methodology.md](https://www.google.com/search?q=./docs/methodology.md)**.
+For the full, unabridged version, see **[./docs/methodology.md](./docs/methodology.md)**.
 
 \</details\>
 
@@ -150,7 +150,7 @@ Quick guide to our categories (and the icons you'll see in the table):
 
 ## 🔄 Changelog
 
-This isn't a static list. It's alive\! See [CHANGELOG.md](https://www.google.com/search?q=./CHANGELOG.md) for all the adds, drops, and major rank shuffles.
+This isn't a static list. It's alive\! See [CHANGELOG.md](./CHANGELOG.md) for all the adds, drops, and major rank shuffles.
 
 -----
 


### PR DESCRIPTION
## Summary
- replace Google search placeholders with real anchors
- fix README table of contents links
- convert local links to relative paths

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `grep -R "google.com/search?q=%23" README.md`


------
https://chatgpt.com/codex/tasks/task_e_684becb986ec832a82b9320ecd89b931