### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -3,12 +3,24 @@ name: Deploy Web
 on:
   push:
     branches: [ main ]
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 jobs:
   build-deploy:
+    if: github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+      - name: Checkout code from workflow run
+        if: github.event_name == 'workflow_run'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -18,7 +30,14 @@ jobs:
       - name: Build
         run: npm run build --prefix web
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: web/dist
+      - name: Comment PR with preview URL
+        if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          body: |
+            🚀 Preview available at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/


### PR DESCRIPTION
## Summary
- update deploy_site workflow to build the web folder and deploy using `peaceiris/actions-gh-pages@v4`
- deploy on push to `main` and on successful `CI` workflow runs
- comment on PRs with a preview URL when available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bece2c8e0832a95a1b35ce3590a85