### PR TITLE
docs: sync examples & badges to Agentic Index

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in improving AgentOps!
+Thanks for your interest in improving Agentic Index!
 
 Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating.
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Want a shortcut? Jump to the [Fast-Start table](FAST_START.md).
 -----
 
 <p align="center">
-<a href="[suspicious link removed]"><img src="[suspicious link removed]" alt="GitHub Stars"></a>
-<a href="[suspicious link removed]"><img src="[suspicious link removed]" alt="Last Commit"></a>
-<a href="./LICENSE.md"><img src="[suspicious link removed]" alt="License"></a>
-<a href="./FAST_START.md"><img src="https://img.shields.io/badge/Fast_Start-Table-blue" alt="Fast Start"></a>
-<a href="./agents.md"><img src="https://img.shields.io/badge/agents-docs-blue" alt="agents"></a>
+<a href="[suspicious link removed]"><img src="[suspicious link removed]" alt="Agentic Index GitHub Stars"></a>
+<a href="[suspicious link removed]"><img src="[suspicious link removed]" alt="Agentic Index Last Commit"></a>
+<a href="./LICENSE.md"><img src="[suspicious link removed]" alt="Agentic Index License"></a>
+<a href="./FAST_START.md"><img src="https://img.shields.io/badge/Agentic%20Index-Fast_Start-blue" alt="Agentic Index Fast Start"></a>
+<a href="./agents.md"><img src="https://img.shields.io/badge/Agentic%20Index-Agents-blue" alt="Agentic Index agents"></a>
 </p>
 
 <p align="center">
@@ -38,7 +38,7 @@ This catalogue is maintained by the AgentOps initiative and is updated regularly
 
 ## TOC
 
-* [✨ Why AgentOps is Different](#why-agentops-is-different)
+* [✨ Why Agentic Index is Different](#why-agentic-index-is-different)
 * [🚀 Fast-Start Picks (Curated for Newcomers)](#fast-start-picks-curated-for-newcomers)
 * [🏆 The AgentOps Top 50: AI Agent Repositories](#the-agentops-top-50-ai-agent-repositories)
   * [💎 Honourable Mentions / Niche & Novel Gems](#honourable-mentions--niche--novel-gems)
@@ -50,7 +50,7 @@ This catalogue is maintained by the AgentOps initiative and is updated regularly
 
 -----
 
-## ✨ Why AgentOps is Different
+## ✨ Why Agentic Index is Different
 
 In the fast-moving world of Agentic-AI, finding high-quality, actively maintained, and truly impactful frameworks can be a pain. Many lists are subjective or just track stars. AgentOps cuts through the noise with an analytical approach:
 
@@ -201,7 +201,7 @@ This isn't a static list. It's alive\! See [CHANGELOG.md](./CHANGELOG.md) for al
 Run the indexer to fetch fresh repo data:
 
 ```bash
-python3 scripts/agentops.py --min-stars 50 --iterations 1 --output data
+python -m agentic_index_cli.agentic_index --min-stars 50 --iterations 1 --output data
 ```
 
 Generated tables live in the `data/` directory.

--- a/agentic_index_cli/__init__.py
+++ b/agentic_index_cli/__init__.py
@@ -1,0 +1,1 @@
+from agentops_cli import *  # re-export for backward compatibility

--- a/agentic_index_cli/agentic_index.py
+++ b/agentic_index_cli/agentic_index.py
@@ -1,0 +1,10 @@
+from agentops_cli.agentops import run_index
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Agentic Index CLI")
+    parser.add_argument("--min-stars", type=int, default=0)
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--output", type=str, default="data")
+    args = parser.parse_args()
+    run_index(args.min_stars, args.iterations, args.output)

--- a/agentic_index_cli/faststart.py
+++ b/agentic_index_cli/faststart.py
@@ -1,0 +1,1 @@
+from agentops_cli.faststart import *

--- a/agentic_index_cli/inject_readme.py
+++ b/agentic_index_cli/inject_readme.py
@@ -1,0 +1,1 @@
+from agentops_cli.inject_readme import *

--- a/agentic_index_cli/plot_trends.py
+++ b/agentic_index_cli/plot_trends.py
@@ -1,0 +1,1 @@
+from agentops_cli.plot_trends import *

--- a/agentic_index_cli/ranker.py
+++ b/agentic_index_cli/ranker.py
@@ -1,0 +1,1 @@
+from agentops_cli.ranker import *

--- a/agentic_index_cli/scraper.py
+++ b/agentic_index_cli/scraper.py
@@ -1,0 +1,1 @@
+from agentops_cli.scraper import *

--- a/agents.md
+++ b/agents.md
@@ -8,11 +8,11 @@ AgentOps curates & ranks AI-agent repos so developers can quickly find reliable 
 
 | Agent Name | Trigger | Code Location | Main Function | Outputs |
 |------------|---------|---------------|---------------|---------|
-| ScraperCLI | manual / update.yml | `agentops_cli/scraper.py` | Fetch repos via GitHub API | `data/repos.json` |
-| RankerCLI | manual / update.yml | `agentops_cli/ranker.py` | Compute score & top-50 | `data/top50.md`, badges |
-| READMEInjector | pre-commit / update.yml | `agentops_cli/inject_readme.py` | Update README table | updated README |
-| FastStartPicker | manual | `agentops_cli/faststart.py` | Generate FAST_START | `FAST_START.md` |
-| TrendGrapher | update.yml | `agentops_cli/plot_trends.py` | Plot score trends | `docs/trends/*.png` |
+| ScraperCLI | manual / update.yml | `agentic_index_cli/scraper.py` | Fetch repos via GitHub API | `data/repos.json` |
+| RankerCLI | manual / update.yml | `agentic_index_cli/ranker.py` | Compute score & top-50 | `data/top50.md`, badges |
+| READMEInjector | pre-commit / update.yml | `agentic_index_cli/inject_readme.py` | Update README table | updated README |
+| FastStartPicker | manual | `agentic_index_cli/faststart.py` | Generate FAST_START | `FAST_START.md` |
+| TrendGrapher | update.yml | `agentic_index_cli/plot_trends.py` | Plot score trends | `docs/trends/*.png` |
 | SiteDeployer | gh-pages | `.github/workflows/deploy_site.yml` | Publish /web to Pages | live site URL |
 
 Add any new agents as you implement them.*
@@ -102,5 +102,5 @@ graph TD
 
 ## 5. Maintenance Notes
 
-- To add a new agent, create a CLI module in `agentops_cli/` and document it in the table above.
+- To add a new agent, create a CLI module in `agentic_index_cli/` and document it in the table above.
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,9 +1,9 @@
 # CLI Usage
 
-The `agentops_cli` module exposes a command line interface for ranking agent frameworks.
+The `agentic_index_cli` module exposes a command line interface for ranking agent frameworks.
 
 Example:
 
 ```bash
-python -m agentops_cli --min-stars 100 --iterations 2 --output ./data
+python -m agentic_index_cli.agentic_index --min-stars 100 --iterations 2 --output ./data
 ```

--- a/docs/reference/agentic_index_cli.md
+++ b/docs/reference/agentic_index_cli.md
@@ -1,4 +1,4 @@
-::: agentops_cli
+::: agentic_index_cli
 handler: python
 rendering:
   show_source: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,4 +9,4 @@ nav:
   - Methodology: METHODOLOGY.md
   - CLI Usage: cli.md
   - API Reference:
-      - agentops_cli: reference/agentops_cli.md
+      - agentic_index_cli: reference/agentic_index_cli.md

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>AgentOps Repo Index</title>
+  <title>Agentic Index Repo Index</title>
   <style>
     body { font-family: sans-serif; padding: 1rem; }
     table { border-collapse: collapse; width: 100%; }
@@ -11,7 +11,7 @@
   </style>
 </head>
 <body>
-  <h1>AgentOps Repository Index</h1>
+  <h1>Agentic Index Repository Index</h1>
   <div id="filters">
     <label>Stars: <input type="range" id="starsRange" min="0" max="20000" step="100" value="0"></label>
     <span id="starsValue">0+</span>


### PR DESCRIPTION
## Summary
- rename CLI docs to `agentic_index_cli`
- update README badges, quick-start command and headings
- update contributing instructions
- change site title
- add `agentic_index_cli` package wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0db9ec64832abfc1a10a45f12f4e