### PR TITLE
ci: daily refresh & auto-merge

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,14 +2,24 @@ name: Update index
 
 on:
   schedule:
-    - cron: '30 2 * * 1'
+    - cron: '30 2 * * *'
   workflow_dispatch:
+    inputs:
+      min-stars:
+        description: "Minimum stars to include"
+        default: '50'
+        required: false
+      auto-merge:
+        description: "Auto-merge PR when checks pass"
+        default: 'false'
+        required: false
 
 jobs:
   update-data:
     runs-on: ubuntu-latest
     env:
       BRANCH: data-update-${{ github.run_id }}
+      MIN_STARS: ${{ github.event.inputs.min-stars || 50 }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -18,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt requests pytest
       - name: Scrape repositories
-        run: python -m agentic_index_cli.scraper --min-stars 50
+        run: python -m agentic_index_cli.scraper --min-stars $MIN_STARS
       - name: Rank repositories
         run: python -m agentic_index_cli.ranker data/repos.json
       - name: Run tests
@@ -38,10 +48,17 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add data/top50.md data/repos.json
-          git commit -m "chore(data): weekly agent index refresh"
+          git commit -m "chore(data): nightly agent index refresh"
           git push --set-upstream origin "$BRANCH"
       - name: Create pull request
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr create --title "chore(data): weekly agent index refresh" --fill --head "$BRANCH" --base main
+        run: gh pr create --title "chore(data): nightly agent index refresh" --fill --head "$BRANCH" --base main
+      - name: Auto-merge
+        if: steps.diff.outputs.changed == 'true' && github.event.inputs.auto-merge == 'true'
+        uses: pascalgn/automerge-action@v0.15.6
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MERGE_LABELS: ""
+          MERGE_METHOD: squash


### PR DESCRIPTION
## Summary
- enable daily refresh of agent index via cron schedule
- allow manual workflow dispatch with inputs for min stars and auto-merge
- support optional auto-merge after checks pass using automerge action

## Testing
- `pytest -q` *(fails: KeyError: 'AgenticIndexScore')*


------
https://chatgpt.com/codex/tasks/task_e_684c1ea9f22c832a9203ba0c0c678650