### PR TITLE
ci: webhook notification on index update

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,35 @@
+name: Refresh notification
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - data/top50.md
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send webhook alert
+        env:
+          WEBHOOK: ${{ secrets.REFRESH_WEBHOOK_URL }}
+        run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "::warning::REFRESH_WEBHOOK_URL not set; skipping notification"
+            exit 0
+          fi
+          payload='{"text": "✅ AgentOps index updated – commit ${{ github.sha }}"}'
+          attempt=0
+          while [ $attempt -lt 3 ]; do
+            status=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H 'Content-Type: application/json' -d "$payload" "$WEBHOOK")
+            if [ "$status" = "200" ]; then
+              echo "Webhook sent"
+              exit 0
+            fi
+            attempt=$((attempt + 1))
+            echo "Attempt $attempt failed with status $status"
+            sleep 2
+          done
+          echo "::error::Failed to send webhook after $attempt attempts"
+          exit 1
+


### PR DESCRIPTION
## Summary
- add GitHub Action to POST to REFRESH_WEBHOOK_URL when `data/top50.md` is updated on main

## Testing
- `pytest -q` *(fails: KeyError in `test_ranking.py`, CalledProcessError in `test_sync.py`)*

------
https://chatgpt.com/codex/tasks/task_e_684c1ef99684832abf02be0144a2f469