### PR TITLE
feat: one-command refresh trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ npx pa11y web/index.html
 
 You can also run `./scripts/install_pa11y_deps.sh` to install pa11y and Chrome.
 
+## 💻 Developer
+
+To trigger a data refresh via GitHub Actions, run:
+
+```bash
+bash scripts/trigger_refresh.sh 75
+```
+
+Replace `75` with your desired minimum star count. The script requires the GitHub CLI and an authenticated token.
+
 -----
 
 ## 🤝 How to Contribute

--- a/scripts/trigger_refresh.sh
+++ b/scripts/trigger_refresh.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Trigger the update workflow for Agentic Index
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: GitHub CLI 'gh' not found. Install from https://cli.github.com/." >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "Error: GitHub CLI is not authenticated. Run 'gh auth login' or set GH_TOKEN." >&2
+  exit 1
+fi
+
+gh workflow run update.yml \
+  -f ref=main \
+  -f min-stars="${1:-50}" \
+  -f auto-merge="true"


### PR DESCRIPTION
## Summary
- add `scripts/trigger_refresh.sh` to easily dispatch the update workflow
- document developer workflow in README

## Testing
- `shellcheck scripts/trigger_refresh.sh`
- `pytest -q` *(fails: KeyError in tests/test_ranking.py and diff check)*

------
https://chatgpt.com/codex/tasks/task_e_684c1eca6f0c832aa6e6a78ac06d5aef