### PR TITLE
docs: refresh pipeline & regression test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+refresh:
+./scripts/trigger_refresh.sh
+

--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ python -m agentic_index_cli.agentic_index --min-stars 50 --iterations 1 --output
 
 Generated tables live in the `data/` directory.
 
+## 🔄 How refresh works
+
+A scheduled GitHub Action keeps the index up to date. It runs the scraper and
+ranker, opens a pull request with any changes, and can auto-merge when all
+checks pass. You can also trigger this process manually by running
+[`scripts/trigger_refresh.sh`](scripts/trigger_refresh.sh).
+
 ## 🧪 Testing
 
 This project uses `pytest` for unit tests and [pa11y](https://github.com/pa11y/pa11y) for accessibility checks. Ensure Chrome is installed before running pa11y:

--- a/docs/REFRESH.md
+++ b/docs/REFRESH.md
@@ -1,0 +1,10 @@
+# Refresh Pipeline
+
+This page explains how the automatic refresh of `repos.json` and the ranking table works.
+
+1. **Cron job** – The `update.yml` workflow runs every night via cron. It installs dependencies, runs the scraper and ranker and commits updates.
+2. **Manual dispatch** – You can trigger the same workflow from the GitHub UI or via `gh workflow run`. Optional inputs allow setting `min-stars` and enabling `auto-merge`.
+3. **Auto-merge** – If `auto-merge` is true, the workflow uses an action to merge the refresh PR once checks succeed.
+4. **Webhook** – After merging, a webhook notifies any downstream services that new data is available.
+
+See [`scripts/trigger_refresh.sh`](../scripts/trigger_refresh.sh) for the command-line helper.

--- a/scripts/rank.py
+++ b/scripts/rank.py
@@ -21,12 +21,12 @@ SCORE_KEY = "AgenticIndexScore"
 
 
 def compute_score(repo: dict) -> float:
-    stars        = repo.get("stars", 0)
-    recency      = repo.get("recency_factor", 0)
+    stars = repo.get("stars", 0)
+    recency = repo.get("recency_factor", 0)
     issue_health = repo.get("issue_health", 0)
-    docs         = repo.get("doc_completeness", 0)
+    docs = repo.get("doc_completeness", 0)
     license_free = repo.get("license_freedom", 0)
-    ecosys       = repo.get("ecosystem_integration", 0)
+    ecosys = repo.get("ecosystem_integration", 0)
     score = (
         0.35 * math.log2(stars + 1)
         + 0.20 * recency
@@ -37,8 +37,15 @@ def compute_score(repo: dict) -> float:
     )
     return round(score, 2)
 
+
 def infer_category(repo: dict) -> str:
-    blob = " ".join(repo.get("topics", [])) + " " + repo.get("description", "") + " " + repo.get("name", "")
+    blob = (
+        " ".join(repo.get("topics", []))
+        + " "
+        + repo.get("description", "")
+        + " "
+        + repo.get("name", "")
+    )
     text = blob.lower()
     if "rag" in text:
         return "RAG-centric"
@@ -50,7 +57,9 @@ def infer_category(repo: dict) -> str:
         return "Experimental"
     return "General-purpose"
 
+
 # ─────────────────────────────  Badge helpers  ─────────────────────────────────
+
 
 def _fetch(url: str, dest: Path) -> None:
     """Download an SVG badge, or write a tiny placeholder if offline."""
@@ -58,19 +67,24 @@ def _fetch(url: str, dest: Path) -> None:
         with urllib.request.urlopen(url) as resp:
             dest.write_bytes(resp.read())
     except Exception:
-        dest.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+        dest.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>\n')
+
 
 def generate_badges(top_repo: str, iso_date: str) -> None:
     badges = Path("badges")
     badges.mkdir(exist_ok=True)
 
-    sync_badge = f"https://img.shields.io/static/v1?label=sync&message={iso_date}&color=blue"
-    top_badge  = f"https://img.shields.io/static/v1?label=top&message={urllib.request.quote(top_repo)}&color=brightgreen"
+    sync_badge = (
+        f"https://img.shields.io/static/v1?label=sync&message={iso_date}&color=blue"
+    )
+    top_badge = f"https://img.shields.io/static/v1?label=top&message={urllib.request.quote(top_repo)}&color=brightgreen"
 
     _fetch(sync_badge, badges / "last_sync.svg")
-    _fetch(top_badge,  badges / "top_repo.svg")
+    _fetch(top_badge, badges / "top_repo.svg")
+
 
 # ───────────────────────────────  Main CLI  ────────────────────────────────────
+
 
 def main(json_path: str = "data/repos.json") -> None:
     data_file = Path(json_path)
@@ -85,7 +99,7 @@ def main(json_path: str = "data/repos.json") -> None:
 
     # score + categorise
     for repo in repos:
-        repo[SCORE_KEY]  = compute_score(repo)
+        repo[SCORE_KEY] = compute_score(repo)
         repo["category"] = infer_category(repo)
 
     # sort & persist
@@ -107,9 +121,10 @@ def main(json_path: str = "data/repos.json") -> None:
         Path("data/top50.md").write_text("\n".join(header + rows) + "\n")
 
     # badges
-    today_iso     = datetime.date.today().isoformat()
+    today_iso = datetime.date.today().isoformat()
     top_repo_name = repos[0]["name"] if repos else "unknown"
     generate_badges(top_repo_name, today_iso)
+
 
 if __name__ == "__main__":
     src = sys.argv[1] if len(sys.argv) > 1 else "data/repos.json"

--- a/scripts/trigger_refresh.sh
+++ b/scripts/trigger_refresh.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Trigger the GitHub Action workflow that refreshes repo data.
+# Requires a GitHub token with workflow scope.
+
+MIN_STARS=${MIN_STARS:-50}
+AUTO_MERGE=${AUTO_MERGE:-false}
+
+echo "Dispatching update workflow..."
+
+gh workflow run update.yml -f min-stars="$MIN_STARS" -f auto-merge="$AUTO_MERGE"

--- a/tests/test_refresh_flags.py
+++ b/tests/test_refresh_flags.py
@@ -1,0 +1,45 @@
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scripts.rank as rank
+import scripts.scrape as scrape
+
+
+def make_response(stars):
+    item = {
+        "name": f"repo{stars}",
+        "full_name": f"owner/repo{stars}",
+        "html_url": "https://example.com",
+        "description": "",
+        "stargazers_count": stars,
+        "forks_count": 0,
+        "open_issues_count": 0,
+        "archived": False,
+        "license": {"spdx_id": "MIT"},
+        "language": "Python",
+        "pushed_at": "2025-01-01T00:00:00Z",
+        "owner": {"login": "owner"},
+    }
+    resp = mock.Mock()
+    resp.json.return_value = {"items": [item]}
+    resp.headers = {"X-RateLimit-Remaining": "100"}
+    resp.links = {}
+    resp.raise_for_status = mock.Mock()
+    return resp
+
+
+def test_refresh_flags(monkeypatch, tmp_path):
+    monkeypatch.setattr(scrape.requests, "get", lambda *a, **kw: make_response(7))
+    repos = scrape.scrape(min_stars=5, token=None)
+    assert repos and all(r["stargazers_count"] >= 5 for r in repos)
+
+    repo_file = tmp_path / "repos.json"
+    repo_file.write_text(json.dumps(repos))
+
+    rank.main(str(repo_file))
+    data = json.loads(repo_file.read_text())
+    assert "AgenticIndexScore" in data[0]


### PR DESCRIPTION
## Summary
- document refresh workflow
- add a REFRESH.md guide
- create script to trigger refresh
- provide Makefile alias for the script
- regression test for refresh flags

## Testing
- `pytest --cov=agentic_index_cli --cov=scripts -q` *(fails: KeyError in test_ranking)*

------
https://chatgpt.com/codex/tasks/task_e_684c208d51b0832a8450f74b710a177b