### PR TITLE
ci: add Trivy security scanning

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,30 @@
+name: Trivy Scan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.14.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: HIGH,CRITICAL
+          exit-code: 1
+          format: sarif
+          output: trivy-results.sarif
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Add vulnerability IDs to ignore specific findings
+


### PR DESCRIPTION
## Summary
- add GitHub workflow to run Trivy on push and PRs
- upload SARIF results to GitHub Security tab
- fail build on high or critical vulnerabilities
- allow suppressing alerts via `.trivyignore`

## Testing
- `pytest -q` *(fails: KeyError: 'AgenticIndexScore')*

------
https://chatgpt.com/codex/tasks/task_e_684c233cc068832ab58ff2370ff7cd9a