### PR TITLE
ci: enable Dependabot updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @adrianwedd

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    assignees:
+      - "adrianwedd"
+    reviewers:
+      - "adrianwedd"
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    assignees:
+      - "adrianwedd"
+    reviewers:
+      - "adrianwedd"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    assignees:
+      - "adrianwedd"
+    reviewers:
+      - "adrianwedd"

--- a/.github/pre-commit-ci.yml
+++ b/.github/pre-commit-ci.yml
@@ -1,0 +1,1 @@
+autofix: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'

--- a/.github/workflows/rank.yml
+++ b/.github/workflows/rank.yml
@@ -9,7 +9,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'


### PR DESCRIPTION
## Summary
- add Dependabot configuration for pip, npm, and GitHub Actions
- assign Dependabot PRs to CODEOWNERS and label them `dependencies`
- add pre-commit.ci config for autoformatting
- update CI workflows to use checkout v4

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/rank.yml .github/dependabot.yml .github/pre-commit-ci.yml .github/CODEOWNERS`
- `pytest -q` *(fails: KeyError: 'AgenticIndexScore')*

------
https://chatgpt.com/codex/tasks/task_e_684c2362a558832aa23db1d9eeff9ade