### PR TITLE
ci: pin valid Trivy action version

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -14,8 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # To update, run:
+      # git ls-remote --tags https://github.com/aquasecurity/trivy-action.git | \
+      #   sort -t '/' -k3 -V | tail -n1
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.14.0
+        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37
         with:
           scan-type: fs
           scan-ref: .


### PR DESCRIPTION
## Summary
- pin aquasecurity/trivy-action to commit SHA
- add instructions for updating the action

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c26805ca0832a8e67bd5a0f4d3c83