### PR TITLE
ci+docs: refine regression guard and restore missing links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: pip install -r requirements.txt
+      - name: Run regression guard
+        run: python scripts/regression_check.py
       - name: Run tests with coverage
         run: pytest --cov=agentic_index_cli --cov-report=xml
         env:
@@ -28,3 +30,5 @@ jobs:
           PY
         env:
           PYTHONHASHSEED: 0
+      - name: Verify internal links
+        run: python scripts/link_integrity.py

--- a/.regression.yml
+++ b/.regression.yml
@@ -1,0 +1,7 @@
+forbidden:
+  - agentops_cli
+  - '"score"'
+  - google.com/search?q=%23
+allowed_regex:
+  - https://github\.com/.*/agentops\b
+  - Fast-Start Picks:.*AgentOps

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Want a shortcut? Jump to the [Fast-Start table](FAST_START.md).
 -----
 
 <p align="center">
-<a href="[suspicious link removed]"><img src="[suspicious link removed]" alt="Agentic Index GitHub Stars"></a>
-<a href="[suspicious link removed]"><img src="[suspicious link removed]" alt="Agentic Index Last Commit"></a>
-<a href="./LICENSE.md"><img src="[suspicious link removed]" alt="Agentic Index License"></a>
+<a href="https://img.shields.io/github/stars/AgentOps/Agentic-Index?style=social"><img src="https://img.shields.io/github/stars/AgentOps/Agentic-Index?style=social" alt="Agentic Index GitHub Stars"></a>
+<a href="https://img.shields.io/github/last-commit/AgentOps/Agentic-Index"><img src="https://img.shields.io/github/last-commit/AgentOps/Agentic-Index" alt="Agentic Index Last Commit"></a>
+<a href="./LICENSE.md"><img src="https://img.shields.io/github/license/AgentOps/Agentic-Index" alt="Agentic Index License"></a>
 <a href="./FAST_START.md"><img src="https://img.shields.io/badge/Agentic%20Index-Fast_Start-blue" alt="Agentic Index Fast Start"></a>
 <a href="./agents.md"><img src="https://img.shields.io/badge/Agentic%20Index-Agents-blue" alt="Agentic Index agents"></a>
 </p>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pytest
 pytest-cov
+requests
+PyYAML

--- a/scripts/link_integrity.py
+++ b/scripts/link_integrity.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Check README and docs for broken internal links and badges."""
+from __future__ import annotations
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import requests
+
+
+HEAD_RE = re.compile(r'^(#+)\s*(.+)$')
+ANCHOR_RE = re.compile(r'\[[^\]]+\]\(#([^\)]+)\)')
+IMG_RE = re.compile(r'!\[[^\]]*\]\(([^)]+)\)')
+HTML_IMG_RE = re.compile(r'<img\s+[^>]*src="([^"]+)"')
+
+
+def slug(text: str) -> str:
+    s = re.sub(r'[\s]+', '-', re.sub(r'[^\x00-\x7F]+', '', text))
+    s = re.sub(r'[^a-zA-Z0-9\- ]', '', s)
+    s = s.replace(' ', '-')
+    return s.lower()
+
+
+def extract_headings(lines: Iterable[str]) -> set[str]:
+    anchors = set()
+    for line in lines:
+        m = HEAD_RE.match(line)
+        if m:
+            anchors.add(slug(m.group(2)))
+    return anchors
+
+
+def check_file(path: Path, headings: set[str], failures: list[str]) -> None:
+    text = path.read_text(encoding='utf-8')
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for anchor in ANCHOR_RE.findall(line):
+            if anchor not in headings:
+                failures.append(f'{path}:{lineno}: missing anchor {anchor}')
+        for img in IMG_RE.findall(line) + HTML_IMG_RE.findall(line):
+            if img.startswith('badges/'):
+                if not Path(img).exists():
+                    failures.append(f'{path}:{lineno}: missing badge {img}')
+            if img.startswith('https://img.shields.io'):
+                if not http_ok(img):
+                    failures.append(f'{path}:{lineno}: badge url bad {img}')
+
+
+def http_ok(url: str) -> bool:
+    for _ in range(2):
+        try:
+            resp = requests.get(url, timeout=3)
+            if resp.status_code == 200:
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def main(paths: Iterable[str] | None = None) -> int:
+    if paths is None:
+        paths = ["README.md"] + [str(p) for p in Path('docs').glob('*.md')]
+    failures: list[str] = []
+    for p in paths:
+        path = Path(p)
+        if not path.exists():
+            continue
+        text = path.read_text(encoding='utf-8').splitlines()
+        headings = extract_headings(text)
+        check_file(path, headings, failures)
+    if failures:
+        print('\n'.join(failures))
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/regression_check.py
+++ b/scripts/regression_check.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Fail CI if forbidden patterns appear in tracked files.
+
+Patterns to block/allow are configured in `.regression.yml`:
+  forbidden: list of substrings
+  allowed_regex: list of regex patterns that override a match
+"""
+from __future__ import annotations
+import re
+import subprocess
+import sys
+from pathlib import Path
+import yaml
+
+CONFIG_PATH = Path('.regression.yml')
+
+
+def load_config(path: Path = CONFIG_PATH) -> dict:
+    if not path.exists():
+        return {"forbidden": [], "allowed_regex": []}
+    with open(path, 'r', encoding='utf-8') as f:
+        cfg = yaml.safe_load(f) or {}
+    cfg.setdefault('forbidden', [])
+    cfg.setdefault('allowed_regex', [])
+    return cfg
+
+
+def gather_files() -> list[Path]:
+    out = subprocess.check_output(['git', 'ls-files'], text=True)
+    return [Path(p) for p in out.splitlines() if p]
+
+
+def check_files(paths: list[Path], config: dict) -> list[str]:
+    allowed = [re.compile(p) for p in config.get('allowed_regex', [])]
+    forbidden = config.get('forbidden', [])
+    failures = []
+    for p in paths:
+        try:
+            text = p.read_text(encoding='utf-8', errors='ignore')
+        except Exception:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for pat in forbidden:
+                if pat in line:
+                    if any(r.search(line) for r in allowed):
+                        break
+                    failures.append(f'{p}:{lineno}: {pat}')
+                    break
+    return failures
+
+
+def main(paths: list[str] | None = None) -> int:
+    cfg = load_config()
+    files = [Path(p) for p in paths] if paths else gather_files()
+    fails = check_files(files, cfg)
+    if fails:
+        print('Forbidden patterns found:')
+        for f in fails:
+            print(f)
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_link_integrity.py
+++ b/tests/test_link_integrity.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scripts.link_integrity as li
+
+
+def test_link_integrity(tmp_path, monkeypatch):
+    md = tmp_path / 'sample.md'
+    md.write_text('# Title\n\n[ok](#title)\n[bad](#missing)\n![](badges/foo.svg)\n![](https://img.shields.io/badge/test-blue)')
+    (tmp_path / 'badges').mkdir()
+    (tmp_path / 'badges' / 'foo.svg').write_text('<svg></svg>')
+
+    # mock requests.get for shields url
+    def fake_get(url, timeout=3):
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(li.requests, 'get', fake_get)
+
+    rc = li.main([str(md)])
+    assert rc == 1  # missing anchor triggers failure

--- a/tests/test_regression_check.py
+++ b/tests/test_regression_check.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scripts.regression_check as rc
+
+
+def test_regression_allows_external_agentops(tmp_path):
+    cfg = tmp_path / '.regression.yml'
+    cfg.write_text('forbidden:\n  - agentops_cli\nallowed_regex:\n  - https://github\\.com/.*/agentops\\b\n')
+    f = tmp_path / 'sample.txt'
+    f.write_text('check https://github.com/foo/agentops for more')
+
+    failures = rc.check_files([f], rc.load_config(cfg))
+    assert not failures
+
+
+def test_regression_blocks_internal(tmp_path):
+    cfg = tmp_path / '.regression.yml'
+    cfg.write_text('forbidden:\n  - agentops_cli\nallowed_regex: []\n')
+    f = tmp_path / 'mod.py'
+    f.write_text('import agentops_cli')
+
+    failures = rc.check_files([f], rc.load_config(cfg))
+    assert failures


### PR DESCRIPTION
## Summary
- add `.regression.yml` and implement regression guard
- restore README shield links
- add link integrity checker
- verify regression/links in CI
- tests for new utilities

## Testing
- `pytest -q`
- `python scripts/link_integrity.py`

------
https://chatgpt.com/codex/tasks/task_e_684c27fcc854832a8ebe316cba2124ae