### PR TITLE
docs: add missing pages to nav & fix script link

### DIFF
--- a/docs/REFRESH.md
+++ b/docs/REFRESH.md
@@ -7,4 +7,4 @@ This page explains how the automatic refresh of `repos.json` and the ranking tab
 3. **Auto-merge** – If `auto-merge` is true, the workflow uses an action to merge the refresh PR once checks succeed.
 4. **Webhook** – After merging, a webhook notifies any downstream services that new data is available.
 
-See [`scripts/trigger_refresh.sh`](../scripts/trigger_refresh.sh) for the command-line helper.
+See [`trigger_refresh.sh`](https://github.com/adrianwedd/Agentic-Index/blob/main/scripts/trigger_refresh.sh) for the command-line helper.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,10 @@ plugins:
   - mkdocstrings
 docs_dir: docs
 nav:
-  - Overview: index.md
+  - Home: index.md
+  - Guides:
+      - Refresh Pipeline: REFRESH.md
+      - CI Audit Report: ci-audit.md
   - Methodology: METHODOLOGY.md
   - CLI Usage: cli.md
   - API Reference:


### PR DESCRIPTION
## Summary
- add Refresh and CI Audit pages to navigation
- make trigger_refresh.sh link external

## Testing
- `pytest -q`
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_684c2a432440832a8065826f053a36fc