### PR TITLE
ci: block external network & mock badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,19 @@ jobs:
           PYTHONHASHSEED: 0
       - name: Verify internal links
         run: python scripts/link_integrity.py
+
+  offline-lint:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Offline network guard
+        run: |
+          pip install pytest-socket
+          pytest --disable-socket -q 2>&1 | tee pytest.log
+          python scripts/network_guard.py pytest.log

--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ Run tests with:
 pytest -q
 ```
 
+CI runs tests with network access disabled. Set `CI_OFFLINE=1` or run
+`pytest --disable-socket` locally to replicate the offline environment.
+
 To check accessibility after building the site:
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pytest
 pytest-cov
 requests
 PyYAML
+pytest-socket
+responses

--- a/scripts/network_guard.py
+++ b/scripts/network_guard.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import re
+import sys
+from pathlib import Path
+
+ALLOW_PATH = Path('.network-allowlist')
+
+def load_allowlist() -> set[str]:
+    if not ALLOW_PATH.exists():
+        return set()
+    return {l.strip() for l in ALLOW_PATH.read_text().splitlines() if l.strip()}
+
+DOMAIN_RE = re.compile(r"domain=['\"]?([\w.-]+)")
+
+
+def parse_domains(text: str) -> set[str]:
+    domains = set()
+    for line in text.splitlines():
+        m = DOMAIN_RE.search(line)
+        if m:
+            domains.add(m.group(1))
+    return domains
+
+
+def main(log_file: str) -> int:
+    text = Path(log_file).read_text(encoding='utf-8', errors='ignore')
+    seen = parse_domains(text)
+    allowed = load_allowlist()
+    bad = [d for d in seen if d not in allowed]
+    if bad:
+        print('Unexpected network domains:', ', '.join(sorted(bad)))
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1]))

--- a/scripts/rank.py
+++ b/scripts/rank.py
@@ -61,8 +61,13 @@ def infer_category(repo: dict) -> str:
 # ─────────────────────────────  Badge helpers  ─────────────────────────────────
 
 
-def _fetch(url: str, dest: Path) -> None:
-    """Download an SVG badge, or write a tiny placeholder if offline."""
+def fetch_badge(url: str, dest: Path) -> None:
+    """Download an SVG badge or create a local placeholder when offline."""
+    if os.getenv("CI_OFFLINE") == "1":
+        if dest.exists():
+            return
+        dest.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>\n')
+        return
     try:
         with urllib.request.urlopen(url) as resp:
             dest.write_bytes(resp.read())
@@ -79,8 +84,8 @@ def generate_badges(top_repo: str, iso_date: str) -> None:
     )
     top_badge = f"https://img.shields.io/static/v1?label=top&message={urllib.request.quote(top_repo)}&color=brightgreen"
 
-    _fetch(sync_badge, badges / "last_sync.svg")
-    _fetch(top_badge, badges / "top_repo.svg")
+    fetch_badge(sync_badge, badges / "last_sync.svg")
+    fetch_badge(top_badge, badges / "top_repo.svg")
 
 
 # ───────────────────────────────  Main CLI  ────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _offline_socket(monkeypatch):
+    if os.getenv("CI_OFFLINE") == "1":
+        import pytest_socket
+        pytest_socket.disable_socket()
+        yield
+        pytest_socket.enable_socket()
+    else:
+        yield

--- a/tests/test_badge_offline.py
+++ b/tests/test_badge_offline.py
@@ -1,0 +1,15 @@
+import os
+from pathlib import Path
+import subprocess
+
+
+def test_badges_offline(monkeypatch, tmp_path):
+    badges = Path('badges')
+    for f in badges.glob('*.svg'):
+        f.unlink()
+    monkeypatch.setenv('CI_OFFLINE', '1')
+    subprocess.run(['python', 'scripts/rank.py'], check=True)
+    for name in ['last_sync.svg', 'top_repo.svg']:
+        p = badges / name
+        assert p.exists()
+        assert '<svg' in p.read_text()

--- a/tests/test_scrape_mock.py
+++ b/tests/test_scrape_mock.py
@@ -1,0 +1,31 @@
+import responses
+import scripts.scrape as scrape
+
+
+@responses.activate
+def test_scrape_mock():
+    item = {
+        "name": "repo",
+        "full_name": "owner/repo",
+        "html_url": "https://example.com/repo",
+        "description": "test repo",
+        "stargazers_count": 1,
+        "forks_count": 0,
+        "open_issues_count": 0,
+        "archived": False,
+        "license": {"spdx_id": "MIT"},
+        "language": "Python",
+        "pushed_at": "2025-01-01T00:00:00Z",
+        "owner": {"login": "owner"},
+    }
+    for _ in scrape.QUERIES:
+        responses.add(
+            responses.GET,
+            "https://api.github.com/search/repositories",
+            json={"items": [item]},
+            headers={"X-RateLimit-Remaining": "99"},
+            match_querystring=False,
+            status=200,
+        )
+    repos = scrape.scrape(min_stars=0, token=None)
+    assert repos and repos[0]["full_name"] == "owner/repo"


### PR DESCRIPTION
## Summary
- add offline network guard with `.network-allowlist`
- fetch badges locally when `CI_OFFLINE=1`
- mock GitHub API calls in new tests
- document offline testing
- add offline-lint CI job

## Testing
- `pytest -q`
- `pytest --disable-socket -q`

------
https://chatgpt.com/codex/tasks/task_e_684c2b7ac074832abc438d032dbc0690