### PR TITLE
ci+docs: optimise merge-conflict workflow

### DIFF
--- a/.github/actions/behind-check/action.yml
+++ b/.github/actions/behind-check/action.yml
@@ -1,0 +1,15 @@
+name: behind-check
+runs:
+  using: composite
+  steps:
+    - run: git fetch --depth=0 origin "$GITHUB_HEAD_REF" "main"
+    - id: compare
+      run: |
+        behind=$(git rev-list --left-right --count origin/$GITHUB_HEAD_REF...origin/main | awk '{print $2}')
+        echo "behind=$behind" >> "$GITHUB_OUTPUT"
+    - run: |
+        if [ "${{ steps.compare.outputs.behind }}" -gt 0 ]; then
+          echo "Branch is behind main by ${{ steps.compare.outputs.behind }} commits" >&2
+          exit 1
+        fi
+      shell: bash

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -1,0 +1,50 @@
+name: Auto Rebase Bot
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  auto-rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        id: stale
+        with:
+          script: |
+            const prs = await github.paginate('GET /repos/${{ github.repository }}/pulls', {state: 'open', per_page: 100});
+            const stale = prs.filter(pr =>
+              pr.labels.some(l => l.name === 'needs-rebase') &&
+              (Date.now() - new Date(pr.updated_at).getTime()) > 259200000
+            );
+            if (stale.length) {
+              const pr = stale[0];
+              console.log(pr.head.ref);
+              return JSON.stringify({branch: pr.head.ref, repo: pr.head.repo.full_name});
+            }
+      - name: Checkout
+        if: steps.stale.outputs.result != ''
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ fromJSON(steps.stale.outputs.result).repo }}
+          ref: ${{ fromJSON(steps.stale.outputs.result).branch }}
+          fetch-depth: 0
+      - name: Rebase
+        if: steps.stale.outputs.result != ''
+        run: |
+          git fetch origin main
+          git rebase origin/main
+      - name: Push branch
+        if: steps.stale.outputs.result != ''
+        run: |
+          git remote set-url origin https://x-access-token:${{ github.token }}@github.com/${{ fromJSON(steps.stale.outputs.result).repo }}
+          git push --force-with-lease
+      - name: Create auto-rebase PR
+        if: steps.stale.outputs.result != ''
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ github.token }}
+          title: auto-rebase
+          body: Automated rebase onto main
+          base: ${{ fromJSON(steps.stale.outputs.result).branch }}
+          branch: auto-rebase-${{ fromJSON(steps.stale.outputs.result).branch }}

--- a/.github/workflows/stale-branch.yml
+++ b/.github/workflows/stale-branch.yml
@@ -1,0 +1,9 @@
+name: Stale Branch Guard
+on: pull_request_target
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'main'
+    steps:
+      - name: Ensure branch is ≤1 commit behind
+        uses: ./.github/actions/behind-check

--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ Check out [CONTRIBUTING.md](./CONTRIBUTING.md) for how to:
   * Suggest tweaks to scoring or categories.
   * Understand what makes a repo eligible.
 
+For tips on keeping your branch in sync with `main` and resolving conflicts, see
+[CONFLICT_RESOLUTION.md](./docs/CONFLICT_RESOLUTION.md).
+
 Let's build the best damn agent list together\!
 <a href="./CODE_OF_CONDUCT.md"><img src="https://img.shields.io/badge/Code_of_Conduct-CC_v2.1-blue" alt="Code of Conduct"></a>
 

--- a/docs/CONFLICT_RESOLUTION.md
+++ b/docs/CONFLICT_RESOLUTION.md
@@ -1,0 +1,20 @@
+# Resolving Merge Conflicts
+
+Pull requests occasionally fall behind `main`. Use this workflow to bring your branch up to date without polluting the history.
+
+```bash
+git fetch origin
+git checkout <feature-branch>
+git rebase origin/main            # fix conflicts as they appear
+git push --force-with-lease
+```
+
+Only use GitHub's web editor for quick documentation fixes when the conflict is trivial. For anything more involved, resolve locally with the steps above.
+
+When committing your fixes, follow this message pattern:
+
+```
+fix: resolve merge conflicts with main
+```
+
+Avoid `git merge main`; rebasing keeps the history linear and reduces noise for reviewers and CI.

--- a/hooks/rebase-upstream.sh
+++ b/hooks/rebase-upstream.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+if git status -uno | grep -q 'behind'; then
+  echo "Warning: branch is behind upstream. Run: git fetch origin && git rebase origin/main" >&2
+fi


### PR DESCRIPTION
## Summary
- document how to rebase when merge conflicts occur
- add stale branch guard check
- create auto rebase workflow
- include behind-check composite action
- add pre-push warning hook
- link conflict guide from README

## Testing
- `pre-commit run --files README.md docs/CONFLICT_RESOLUTION.md .github/workflows/stale-branch.yml .github/workflows/auto-rebase.yml .github/actions/behind-check/action.yml hooks/rebase-upstream.sh`
- `pytest -q` *(fails: ImportError: cannot import name 'agentops' from 'scripts')*

------
https://chatgpt.com/codex/tasks/task_e_684c331c4944832aa7a0173f857eef4b