### PR TITLE
ci: write-permissions & nav fix for gh-pages

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,8 @@ nav:
   - Guides:
       - Refresh Pipeline: REFRESH.md
       - CI Audit Report: ci-audit.md
+      - Conflict Resolution: CONFLICT_RESOLUTION.md
+      - Coverage Baseline: coverage_baseline.md
   - Methodology: METHODOLOGY.md
   - CLI Usage: cli.md
   - API Reference:


### PR DESCRIPTION
## Summary
- allow the docs deploy workflow to push to `gh-pages`
- link orphan documentation pages so MkDocs strict mode is quiet

## Testing
- `mkdocs build --strict`
- `pytest -q` *(fails: cannot import name 'agentops')*

------
https://chatgpt.com/codex/tasks/task_e_684c35955df4832a9e607de36a3a0b26