### PR TITLE
tests: update imports to agentic_index_cli

### DIFF
--- a/.regression.yml
+++ b/.regression.yml
@@ -1,5 +1,6 @@
 forbidden:
   - agentops_cli
+  - agentops
   - '"score"'
   - google.com/search?q=%23
 allowed_regex:

--- a/agentic_index_cli/internal/inject_readme.py
+++ b/agentic_index_cli/internal/inject_readme.py
@@ -1,0 +1,32 @@
+"""Inject top50 table into README.md."""
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+README_PATH = ROOT / "README.md"
+DATA_PATH = ROOT / "data" / "top50.md"
+
+START = "<!-- TOP50:START -->"
+END = "<!-- TOP50:END -->"
+
+
+def main() -> int:
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    end_newline = readme_text.endswith("\n")
+    try:
+        start_idx = readme_text.index(START)
+        end_idx = readme_text.index(END, start_idx)
+    except ValueError:
+        print("Markers not found in README.md", file=sys.stderr)
+        return 1
+    before = readme_text[: start_idx + len(START)]
+    after = readme_text[end_idx:]
+    table = DATA_PATH.read_text(encoding="utf-8").rstrip("\n") + "\n"
+    new_text = before + "\n" + table + END + after[len(END):]
+    if end_newline and not new_text.endswith("\n"):
+        new_text += "\n"
+    elif not end_newline:
+        new_text = new_text.rstrip("\n")
+    if new_text != readme_text:
+        README_PATH.write_text(new_text, encoding="utf-8")
+    return 0

--- a/agentic_index_cli/internal/link_integrity.py
+++ b/agentic_index_cli/internal/link_integrity.py
@@ -1,0 +1,73 @@
+"""Check README and docs for broken internal links and badges."""
+from __future__ import annotations
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import requests
+
+HEAD_RE = re.compile(r'^(#+)\s*(.+)$')
+ANCHOR_RE = re.compile(r'\[[^\]]+\]\(#([^\)]+)\)')
+IMG_RE = re.compile(r'!\[[^\]]*\]\(([^)]+)\)')
+HTML_IMG_RE = re.compile(r'<img\s+[^>]*src="([^"]+)"')
+
+
+def slug(text: str) -> str:
+    s = re.sub(r'[\s]+', '-', re.sub(r'[^\x00-\x7F]+', '', text))
+    s = re.sub(r'[^a-zA-Z0-9\- ]', '', s)
+    s = s.replace(' ', '-')
+    return s.lower()
+
+
+def extract_headings(lines: Iterable[str]) -> set[str]:
+    anchors = set()
+    for line in lines:
+        m = HEAD_RE.match(line)
+        if m:
+            anchors.add(slug(m.group(2)))
+    return anchors
+
+
+def check_file(path: Path, headings: set[str], failures: list[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for anchor in ANCHOR_RE.findall(line):
+            if anchor not in headings:
+                failures.append(f"{path}:{lineno}: missing anchor {anchor}")
+        for img in IMG_RE.findall(line) + HTML_IMG_RE.findall(line):
+            if img.startswith("badges/"):
+                if not Path(img).exists():
+                    failures.append(f"{path}:{lineno}: missing badge {img}")
+            if img.startswith("https://img.shields.io"):
+                if not http_ok(img):
+                    failures.append(f"{path}:{lineno}: badge url bad {img}")
+
+
+def http_ok(url: str) -> bool:
+    for _ in range(2):
+        try:
+            resp = requests.get(url, timeout=3)
+            if resp.status_code == 200:
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def main(paths: Iterable[str] | None = None) -> int:
+    if paths is None:
+        paths = ["README.md"] + [str(p) for p in Path("docs").glob("*.md")]
+    failures: list[str] = []
+    for p in paths:
+        path = Path(p)
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8").splitlines()
+        headings = extract_headings(text)
+        check_file(path, headings, failures)
+    if failures:
+        print("\n".join(failures))
+        return 1
+    return 0
+

--- a/agentic_index_cli/internal/rank.py
+++ b/agentic_index_cli/internal/rank.py
@@ -1,0 +1,139 @@
+
+"""
+Rank agentic-AI repos, write a Markdown table, and emit Shields.io badges
+showing the last sync date and today’s top-ranked repo.
+
+Usage:
+    python extend_rank.py [data/repos.json]
+"""
+
+import datetime
+import json
+import math
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+# ─────────────────────────  Scoring & categorisation  ──────────────────────────
+
+SCORE_KEY = "AgenticIndexScore"
+
+
+def compute_score(repo: dict) -> float:
+    stars = repo.get("stars", 0)
+    recency = repo.get("recency_factor", 0)
+    issue_health = repo.get("issue_health", 0)
+    docs = repo.get("doc_completeness", 0)
+    license_free = repo.get("license_freedom", 0)
+    ecosys = repo.get("ecosystem_integration", 0)
+    score = (
+        0.35 * math.log2(stars + 1)
+        + 0.20 * recency
+        + 0.15 * issue_health
+        + 0.15 * docs
+        + 0.10 * license_free
+        + 0.05 * ecosys
+    )
+    return round(score, 2)
+
+
+def infer_category(repo: dict) -> str:
+    blob = (
+        " ".join(repo.get("topics", []))
+        + " "
+        + repo.get("description", "")
+        + " "
+        + repo.get("name", "")
+    )
+    text = blob.lower()
+    if "rag" in text:
+        return "RAG-centric"
+    if "multi-agent" in text or "multi agent" in text or "crew" in text:
+        return "Multi-Agent Coordination"
+    if "devtool" in text or "runtime" in text or "tool" in text:
+        return "DevTools"
+    if "experiment" in text or "research" in text:
+        return "Experimental"
+    return "General-purpose"
+
+
+# ─────────────────────────────  Badge helpers  ─────────────────────────────────
+
+
+def fetch_badge(url: str, dest: Path) -> None:
+    """Download an SVG badge or create a local placeholder when offline."""
+    if os.getenv("CI_OFFLINE") == "1":
+        if dest.exists():
+            return
+        dest.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>\n')
+        return
+    try:
+        with urllib.request.urlopen(url) as resp:
+            dest.write_bytes(resp.read())
+    except Exception:
+        if dest.exists():
+            return
+        dest.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>\n')
+
+
+def generate_badges(top_repo: str, iso_date: str) -> None:
+    badges = Path("badges")
+    badges.mkdir(exist_ok=True)
+
+    sync_badge = (
+        f"https://img.shields.io/static/v1?label=sync&message={iso_date}&color=blue"
+    )
+    top_badge = f"https://img.shields.io/static/v1?label=top&message={urllib.request.quote(top_repo)}&color=brightgreen"
+
+    fetch_badge(sync_badge, badges / "last_sync.svg")
+    fetch_badge(top_badge, badges / "top_repo.svg")
+
+
+# ───────────────────────────────  Main CLI  ────────────────────────────────────
+
+
+def main(json_path: str = "data/repos.json") -> None:
+    data_file = Path(json_path)
+    repos = json.loads(data_file.read_text())
+    # temporary shim for older data files
+    for repo in repos:
+        if "AgentOpsScore" in repo:
+            repo[SCORE_KEY] = repo.pop("AgentOpsScore")
+        if 'score' in repo and SCORE_KEY not in repo:
+            repo[SCORE_KEY] = repo.pop('score')
+    is_test = os.getenv("PYTEST_CURRENT_TEST") is not None
+    # avoid mutating tracked repo files during tests
+    skip_repo_write = is_test and Path(json_path).resolve() == Path("data/repos.json").resolve()
+    skip_top_write = is_test
+
+    # score + categorise
+    for repo in repos:
+        repo[SCORE_KEY] = compute_score(repo)
+        repo["category"] = infer_category(repo)
+
+    # sort & persist
+    repos.sort(key=lambda r: r[SCORE_KEY], reverse=True)
+    if not skip_repo_write:
+        data_file.write_text(json.dumps(repos, indent=2))
+
+    # top-50 table
+    header = [
+        "| Rank | Repo | Score | Category |",
+        "|------|------|-------|----------|",
+    ]
+    rows = [
+        f"| {i} | {repo['name']} | {repo[SCORE_KEY]} | {repo['category']} |"
+        for i, repo in enumerate(repos[:50], start=1)
+    ]
+    if not skip_top_write:
+        Path("data").mkdir(exist_ok=True)
+        Path("data/top50.md").write_text("\n".join(header + rows) + "\n")
+
+    # badges
+    today_iso = datetime.date.today().isoformat()
+    top_repo_name = repos[0]["name"] if repos else "unknown"
+    generate_badges(top_repo_name, today_iso)
+
+
+

--- a/agentic_index_cli/internal/regression_check.py
+++ b/agentic_index_cli/internal/regression_check.py
@@ -1,0 +1,67 @@
+
+"""Fail CI if forbidden patterns appear in tracked files.
+
+Patterns to block/allow are configured in `.regression.yml`:
+  forbidden: list of substrings
+  allowed_regex: list of regex patterns that override a match
+"""
+from __future__ import annotations
+import re
+import subprocess
+import sys
+from pathlib import Path
+import yaml
+
+CONFIG_PATH = Path('.regression.yml')
+
+
+def load_config(path: Path = CONFIG_PATH) -> dict:
+    if not path.exists():
+        return {"forbidden": [], "allowed_regex": []}
+    with open(path, 'r', encoding='utf-8') as f:
+        cfg = yaml.safe_load(f) or {}
+    cfg.setdefault('forbidden', [])
+    cfg.setdefault('allowed_regex', [])
+    return cfg
+
+
+def gather_files() -> list[Path]:
+    out = subprocess.check_output(['git', 'ls-files'], text=True)
+    files = [Path(p) for p in out.splitlines() if p]
+    return [p for p in files if p != CONFIG_PATH]
+
+
+def check_files(paths: list[Path], config: dict) -> list[str]:
+    allowed = [re.compile(p) for p in config.get('allowed_regex', [])]
+    forbidden = config.get('forbidden', [])
+    failures = []
+    for p in paths:
+        if p.resolve() == CONFIG_PATH.resolve():
+            continue
+        try:
+            text = p.read_text(encoding='utf-8', errors='ignore')
+        except Exception:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for pat in forbidden:
+                if pat in line:
+                    if any(r.search(line) for r in allowed):
+                        break
+                    failures.append(f'{p}:{lineno}: {pat}')
+                    break
+    return failures
+
+
+def main(paths: list[str] | None = None) -> int:
+    cfg = load_config()
+    files = [Path(p) for p in paths] if paths else gather_files()
+    fails = check_files(files, cfg)
+    if fails:
+        print('Forbidden patterns found:')
+        for f in fails:
+            print(f)
+        return 1
+    return 0
+
+
+

--- a/agentic_index_cli/internal/scrape.py
+++ b/agentic_index_cli/internal/scrape.py
@@ -1,0 +1,92 @@
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import List, Dict, Any
+import requests
+
+RATE_LIMIT_REMAINING = None
+
+QUERIES = [
+    "agent framework",
+    "autonomous agent",
+    "LLM agent",
+    "AI agent",
+]
+
+FIELDS = [
+    "name",
+    "full_name",
+    "html_url",
+    "description",
+    "stargazers_count",
+    "forks_count",
+    "open_issues_count",
+    "archived",
+    "license",
+    "language",
+    "pushed_at",
+    "owner",
+]
+
+def _extract(item: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "name": item.get("name"),
+        "full_name": item.get("full_name"),
+        "html_url": item.get("html_url"),
+        "description": item.get("description"),
+        "stargazers_count": item.get("stargazers_count"),
+        "forks_count": item.get("forks_count"),
+        "open_issues_count": item.get("open_issues_count"),
+        "archived": item.get("archived"),
+        "license": {"spdx_id": (item.get("license") or {}).get("spdx_id")},
+        "language": item.get("language"),
+        "pushed_at": item.get("pushed_at"),
+        "owner": {"login": (item.get("owner") or {}).get("login")},
+    }
+
+
+def scrape(min_stars: int = 0, token: str | None = None) -> List[Dict[str, Any]]:
+    global RATE_LIMIT_REMAINING
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+    all_repos: Dict[str, Dict[str, Any]] = {}
+    for query in QUERIES:
+        params = {
+            "q": f"{query} stars:>={min_stars}",
+            "sort": "stars",
+            "order": "desc",
+            "per_page": 100,
+        }
+        response = requests.get(
+            "https://api.github.com/search/repositories",
+            headers=headers,
+            params=params,
+        )
+        response.raise_for_status()
+        remaining = int(response.headers.get("X-RateLimit-Remaining", "0"))
+        if RATE_LIMIT_REMAINING is None or remaining < RATE_LIMIT_REMAINING:
+            RATE_LIMIT_REMAINING = remaining
+        for item in response.json().get("items", []):
+            data = _extract(item)
+            all_repos[data["full_name"]] = data
+    return list(all_repos.values())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch GitHub repos for Agentic Index")
+    parser.add_argument("--min-stars", type=int, default=0, dest="min_stars")
+    args = parser.parse_args()
+    token = os.getenv("GITHUB_TOKEN")
+    repos = scrape(min_stars=args.min_stars, token=token)
+    path = Path("data/repos.json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(repos, f, ensure_ascii=False, indent=2)
+    print(f"Wrote {len(repos)} repos to {path}")
+    if RATE_LIMIT_REMAINING is not None:
+        print(f"Rate limit remaining: {RATE_LIMIT_REMAINING}")
+
+
+

--- a/agentic_index_cli/rank.py
+++ b/agentic_index_cli/rank.py
@@ -1,0 +1,11 @@
+"""Public ranking helpers."""
+from typing import Dict
+
+from .agentic_index import compute_score as _compute_score
+
+__all__ = ["compute_score"]
+
+
+def compute_score(repo: Dict, readme: str) -> float:
+    """Proxy to :func:`agentic_index_cli.agentic_index.compute_score`."""
+    return _compute_score(repo, readme)

--- a/tests/test_inject_script.py
+++ b/tests/test_inject_script.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import scripts.inject_readme as inj
+import agentic_index_cli.internal.inject_readme as inj
 
 
 def test_inject_readme(tmp_path, monkeypatch):

--- a/tests/test_link_integrity.py
+++ b/tests/test_link_integrity.py
@@ -1,10 +1,6 @@
-import sys
-from pathlib import Path
 from types import SimpleNamespace
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-import scripts.link_integrity as li
+import agentic_index_cli.internal.link_integrity as li
 
 
 def test_link_integrity(tmp_path, monkeypatch):

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -1,9 +1,6 @@
 from unittest import mock
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import scripts.scrape as scrape
+import agentic_index_cli.internal.scrape as scrape
 
 
 def make_response(remaining):
@@ -17,7 +14,7 @@ def make_response(remaining):
 
 def test_rate_limit_drops():
     responses = [make_response(100), make_response(99), make_response(98), make_response(97)]
-    with mock.patch("scripts.scrape.requests.get", side_effect=responses) as get:
+    with mock.patch("agentic_index_cli.internal.scrape.requests.get", side_effect=responses) as get:
         scrape.scrape(min_stars=0, token=None)
         assert scrape.RATE_LIMIT_REMAINING == 97
         assert int(responses[0].headers["X-RateLimit-Remaining"]) > scrape.RATE_LIMIT_REMAINING

--- a/tests/test_rank_cli.py
+++ b/tests/test_rank_cli.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 from pathlib import Path
 
-import scripts.rank as rank
 
 
 def test_rank_ordering_and_tiebreak(tmp_path, monkeypatch):

--- a/tests/test_refresh_flags.py
+++ b/tests/test_refresh_flags.py
@@ -1,12 +1,9 @@
 import json
-import sys
 from pathlib import Path
 from unittest import mock
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-import scripts.rank as rank
-import scripts.scrape as scrape
+import agentic_index_cli.internal.rank as rank
+import agentic_index_cli.internal.scrape as scrape
 
 
 def make_response(stars):

--- a/tests/test_regression_check.py
+++ b/tests/test_regression_check.py
@@ -1,9 +1,4 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-import scripts.regression_check as rc
+import agentic_index_cli.internal.regression_check as rc
 
 
 def test_regression_allows_external_agentops(tmp_path):

--- a/tests/test_score_fuzz.py
+++ b/tests/test_score_fuzz.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from hypothesis import given, strategies as st
 
-from scripts import agentops
+from agentic_index_cli.rank import compute_score
 
 
 # Helper to build minimal repo dict for compute_score
@@ -36,8 +36,8 @@ def test_score_monotonic_and_range(stars1, stars2, open_issues, closed_issues, d
     repo_high = _repo(stars2, open_issues, closed_issues, days)
     readme = "word " * 300 + "```code```"
 
-    score_low = agentops.compute_score(repo_low, readme)
-    score_high = agentops.compute_score(repo_high, readme)
+    score_low = compute_score(repo_low, readme)
+    score_high = compute_score(repo_high, readme)
 
     assert 0 <= score_low <= 100
     assert 0 <= score_high <= 100

--- a/tests/test_scrape_mock.py
+++ b/tests/test_scrape_mock.py
@@ -1,5 +1,5 @@
 import responses
-import scripts.scrape as scrape
+import agentic_index_cli.internal.scrape as scrape
 
 
 @responses.activate


### PR DESCRIPTION
## Summary
- fix imports to reference `agentic_index_cli`
- move helpers from scripts/ into package
- guard against "agentops" strings in regression checker
- expose `compute_score` via `agentic_index_cli.rank`

## Testing
- `pytest --disable-socket --cov=agentic_index_cli --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_684c37234d4c832ab8f0e2cf6b495748