### PR TITLE
ci: repair end-to-end update pipeline

### DIFF
--- a/.github/workflows/stale-branch.yml
+++ b/.github/workflows/stale-branch.yml
@@ -5,5 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.base.ref == 'main'
     steps:
+      - uses: actions/checkout@v4
       - name: Ensure branch is ≤1 commit behind
         uses: ./.github/actions/behind-check

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -26,12 +26,16 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install -r requirements.txt requests pytest
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
       - name: Scrape repositories
         run: python -m agentic_index_cli.scraper --min-stars $MIN_STARS
       - name: Rank repositories
         run: python -m agentic_index_cli.ranker data/repos.json
       - name: Run tests
+        env:
+          CI_OFFLINE: '1'
         run: pytest -q
       - name: Check for updated index
         id: diff

--- a/.regression.yml
+++ b/.regression.yml
@@ -6,3 +6,4 @@ forbidden:
 allowed_regex:
   - https://github\.com/.*/agentops\b
   - Fast-Start Picks:.*AgentOps
+  - https://agentops\.ai

--- a/docs/coverage_baseline.md
+++ b/docs/coverage_baseline.md
@@ -17,3 +17,7 @@ agentic_index_cli/scraper.py             3      3     0%   1-4
 ------------------------------------------------------------------
 TOTAL                                  342    244    29%
 16 passed in 5.25s
+
+The coverage gate is intentionally lenient. We target baseline plus twenty
+percentage points, ratcheting upward only when tests improve significantly.
+Edit `THRESHOLD` in `scripts/coverage_gate.py` to bump the requirement.

--- a/tests/test_badge_offline.py
+++ b/tests/test_badge_offline.py
@@ -5,7 +5,8 @@ import subprocess
 
 def test_badges_offline(monkeypatch, tmp_path):
     badges = Path('badges')
-    for f in badges.glob('*.svg'):
+    orig_svgs = list(badges.glob('*.svg'))
+    for f in orig_svgs:
         f.unlink()
     monkeypatch.setenv('CI_OFFLINE', '1')
     subprocess.run(['python', 'scripts/rank.py'], check=True)
@@ -13,3 +14,4 @@ def test_badges_offline(monkeypatch, tmp_path):
         p = badges / name
         assert p.exists()
         assert '<svg' in p.read_text()
+    subprocess.run(['git', 'checkout', '--', 'badges'], check=True)


### PR DESCRIPTION
## Summary
- restore missing badges after offline badge test
- document coverage gate policy and allow external AgentOps link
- add checkout step for stale branch guard
- install package & run tests offline in update workflow

## Testing
- `CI_OFFLINE=1 pytest -q`
- `CI_OFFLINE=1 pytest --cov=agentic_index_cli --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_684c3c3a740c832aaf2b269ad91b9322