### PR TITLE
ci: add safe, label-gated auto-rebase action

### DIFF
--- a/.github/actions/safe-rebase/action.yml
+++ b/.github/actions/safe-rebase/action.yml
@@ -1,0 +1,43 @@
+name: safe-rebase
+description: Rebase PR branch into new branch <orig>-rebased
+inputs:
+  label:
+    default: needs-rebase
+    required: false
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with: {fetch-depth: 0}
+    - name: Guard label
+      run: |
+        if ! gh pr view ${{ github.event.pull_request.number }} --json labels \
+             | jq -e ".labels[].name==\"${{ inputs.label }}\"" > /dev/null; then
+          echo "Label not present; skipping." && exit 0
+        fi
+    - name: Detect refs
+      id: refs
+      run: |
+        BRANCH=${{ github.head_ref }}
+        BASE=${{ github.base_ref }}
+        REBASE_BRANCH=${BRANCH}-rebased
+        echo "branch=$BRANCH"         >> "$GITHUB_OUTPUT"
+        echo "base=$BASE"             >> "$GITHUB_OUTPUT"
+        echo "rebase_branch=$REBASE_BRANCH" >> "$GITHUB_OUTPUT"
+    - name: Perform rebase
+      run: |
+        git fetch origin ${{ steps.refs.outputs.base }}
+        git checkout -B ${{ steps.refs.outputs.rebase_branch }}
+        git merge --strategy-option theirs origin/${{ steps.refs.outputs.base }} --no-edit
+    - name: Push new branch
+      run: git push -u origin ${{ steps.refs.outputs.rebase_branch }}
+    - name: Open draft PR
+      env: {GH_TOKEN: ${{ github.token }}}
+      run: |
+        gh pr create \
+          --title "Rebase: ${{ steps.refs.outputs.branch }} → ${{ steps.refs.outputs.base }}" \
+          --head ${{ steps.refs.outputs.rebase_branch }} \
+          --base ${{ steps.refs.outputs.base }} \
+          --draft \
+          --body "Automated rebase of **${{ steps.refs.outputs.branch }}**. Review & merge if satisfied."
+

--- a/.github/workflows/safe-rebase.yml
+++ b/.github/workflows/safe-rebase.yml
@@ -1,0 +1,14 @@
+name: Safe Rebase & Retry
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rebase:
+    if: |
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/rebase')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/safe-rebase
+

--- a/agents.md
+++ b/agents.md
@@ -14,6 +14,7 @@ Agentic Index curates & ranks AI-agent repos so developers can quickly find reli
 | FastStartPicker | manual | `agentic_index_cli/faststart.py` | Generate FAST_START | `FAST_START.md` |
 | TrendGrapher | update.yml | `agentic_index_cli/plot_trends.py` | Plot score trends | `docs/trends/*.png` |
 | SiteDeployer | gh-pages | `.github/workflows/deploy_site.yml` | Publish /web to Pages | live site URL |
+| SafeRebase | comment /rebase | `.github/actions/safe-rebase/action.yml` | Rebase PR into new branch | draft <orig>-rebased PR |
 
 Add any new agents as you implement them.*
 

--- a/docs/CONFLICT_RESOLUTION.md
+++ b/docs/CONFLICT_RESOLUTION.md
@@ -23,3 +23,9 @@ Avoid `git merge main`; rebasing keeps the history linear and reduces noise for 
 
 For `update.yml` to refresh the data automatically, GitHub Actions must be allowed to open pull requests. Enable this under **Settings ▸ Actions ▸ General ▸ Workflow permissions** by checking “Allow GitHub Actions to create pull requests.” If you plan to let the bot auto-merge its PRs, also check “Allow GitHub Actions to approve pull requests.” Ensure branch protection rules still require status checks to pass.
 
+## Automated Rebase
+
+1. Add the `needs-rebase` label to your pull request.
+2. Comment `/rebase` on the PR.
+3. The bot opens a draft PR named `<original>-rebased` for review.
+


### PR DESCRIPTION
## Summary
- add `safe-rebase` composite action
- enable `/rebase` comment workflow to open draft PRs
- document the automated rebase workflow
- list SafeRebase agent in `agents.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c442fe9b0832aa4de27e4a0eb78e8