### PR TITLE
tests: make README injector idempotent & fix sync test

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ The definitive list of Agentic-AI repositories, ranked by the Agentic Index Scor
 | 49 | agency-swarm | 0.0 | General-purpose |
 | 50 | AdalFlow | 0.0 | General-purpose |
 <!-- TOP50:END -->
-
 *➡️ Dig into how these scores are cooked up in our [Methodology section](#our-methodology--scoring-explained) and the [full recipe in /docs/methodology.md](./docs/methodology.md).*
 
 -----

--- a/agentic_index_cli/internal/inject_readme.py
+++ b/agentic_index_cli/internal/inject_readme.py
@@ -19,14 +19,27 @@ def main() -> int:
     except ValueError:
         print("Markers not found in README.md", file=sys.stderr)
         return 1
-    before = readme_text[: start_idx + len(START)]
-    after = readme_text[end_idx:]
-    table = DATA_PATH.read_text(encoding="utf-8").rstrip("\n") + "\n"
-    new_text = before + "\n" + table + END + after[len(END):]
-    if end_newline and not new_text.endswith("\n"):
+
+    before = readme_text[: start_idx + len(START)].rstrip()
+    after = "\n" + readme_text[end_idx + len(END):].lstrip()
+
+    lines = [l.strip() for l in DATA_PATH.read_text(encoding="utf-8").splitlines()]
+    header = lines[:2]
+    rows = lines[2:]
+
+    def rank_key(line: str) -> int:
+        parts = line.split("|")
+        return int(parts[1].strip()) if len(parts) > 2 else 0
+
+    rows = sorted(rows, key=rank_key)
+    table = "\n".join(header + rows)
+
+    new_text = f"{before}\n{table}\n{END}{after}"
+    new_text = new_text.rstrip("\n")
+    if end_newline:
         new_text += "\n"
-    elif not end_newline:
-        new_text = new_text.rstrip("\n")
+
     if new_text != readme_text:
         README_PATH.write_text(new_text, encoding="utf-8")
+
     return 0

--- a/scripts/inject_readme.py
+++ b/scripts/inject_readme.py
@@ -23,17 +23,23 @@ def main() -> int:
         print("Markers not found in README.md", file=sys.stderr)
         return 1
 
-    before = readme_text[: start_idx + len(START)]
-    after = readme_text[end_idx:]
+    before = readme_text[: start_idx + len(START)].rstrip()
+    after = "\n" + readme_text[end_idx + len(END):].lstrip()
 
-    table = DATA_PATH.read_text(encoding="utf-8").rstrip("\n") + "\n"
+    lines = [l.strip() for l in DATA_PATH.read_text(encoding="utf-8").splitlines()]
+    header = lines[:2]
+    rows = lines[2:]
+    def rank_key(line: str) -> int:
+        parts = line.split("|")
+        return int(parts[1].strip()) if len(parts) > 2 else 0
 
-    new_text = before + "\n" + table + END + after[len(END):]
+    rows = sorted(rows, key=rank_key)
+    table = "\n".join(header + rows)
 
-    if end_newline and not new_text.endswith("\n"):
+    new_text = f"{before}\n{table}\n{END}{after}"
+    new_text = new_text.rstrip("\n")
+    if end_newline:
         new_text += "\n"
-    elif not end_newline:
-        new_text = new_text.rstrip("\n")
 
     if new_text != readme_text:
         README_PATH.write_text(new_text, encoding="utf-8")

--- a/tests/test_scrape_mock.py
+++ b/tests/test_scrape_mock.py
@@ -4,6 +4,8 @@ import agentic_index_cli.internal.scrape as scrape
 
 @responses.activate
 def test_scrape_mock():
+    import warnings
+    warnings.filterwarnings("ignore", category=DeprecationWarning, module="responses")
     item = {
         "name": "repo",
         "full_name": "owner/repo",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,8 +2,16 @@ import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+INJECT = str(ROOT / "scripts" / "inject_readme.py")
 
 
 def test_readme_synced():
-    subprocess.run([str(ROOT / 'scripts' / 'inject_readme.py')], check=True)
-    subprocess.run(['git', 'diff', '--exit-code'], cwd=ROOT, check=True)
+    subprocess.run([INJECT], check=True)
+    subprocess.run(["git", "diff", "--exit-code", "--", "README.md"], check=True)
+
+
+def test_inject_idempotent(tmp_path):
+    orig = (ROOT / "README.md").read_text()
+    subprocess.run([INJECT], check=True)
+    subprocess.run([INJECT], check=True)
+    assert (ROOT / "README.md").read_text() == orig


### PR DESCRIPTION
## Summary
- ensure README injection script is deterministic
- validate README sync in tests
- add an idempotence check for the README injector
- silence responses deprecation warnings
- update README with latest injected table

## Testing
- `CI_OFFLINE=1 PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4d278890832aabb387cd275733c9