### PR TITLE
ci: correct change-detection for nightly refresh

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -42,15 +42,19 @@ jobs:
           CI_OFFLINE: '1'
         run: pytest -q
       - name: Check for updated index
-        id: diff
+        id: detect-changes
+        shell: bash
         run: |
-          if git diff --quiet --exit-code data/top50.md; then
+          if git diff --quiet --exit-code \
+                data/top50.md data/repos.json README.md; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+      - run: git status --short
+        if: steps.detect-changes.outputs.changed == 'true'
       - name: Create refresh PR
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.detect-changes.outputs.changed == 'true'
         id: createpr
         uses: peter-evans/create-pull-request@v6
         with:

--- a/docs/REFRESH.md
+++ b/docs/REFRESH.md
@@ -7,4 +7,8 @@ This page explains how the automatic refresh of `repos.json` and the ranking tab
 3. **Auto-merge** – If `auto-merge` is true, the workflow uses an action to merge the refresh PR once checks succeed.
 4. **Webhook** – After merging, a webhook notifies any downstream services that new data is available.
 
+The workflow creates a refresh pull request only when any of
+`data/top50.md`, `data/repos.json`, or `README.md` change during the run.
+If nothing changes, the job ends without opening a PR.
+
 See [`trigger_refresh.sh`](https://github.com/adrianwedd/Agentic-Index/blob/main/scripts/trigger_refresh.sh) for the command-line helper.

--- a/tests/test_update_diff.py
+++ b/tests/test_update_diff.py
@@ -1,0 +1,43 @@
+import subprocess
+
+
+def detect_changes(repo):
+    cmd = [
+        "bash",
+        "-c",
+        (
+            "if git diff --quiet --exit-code "
+            "data/top50.md data/repos.json README.md; then "
+            "echo changed=false; else echo changed=true; fi"
+        ),
+    ]
+    result = subprocess.run(cmd, cwd=repo, capture_output=True, text=True)
+    return "changed=true" in result.stdout
+
+
+def setup_repo(tmp_path):
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data/top50.md").write_text("one")
+    (tmp_path / "data/repos.json").write_text("{}")
+    (tmp_path / "README.md").write_text("readme")
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Tester"], cwd=tmp_path, check=True
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, check=True)
+
+
+def test_detect_changes_true(tmp_path):
+    setup_repo(tmp_path)
+    (tmp_path / "data/top50.md").write_text("two")
+    assert detect_changes(tmp_path) is True
+
+
+def test_detect_changes_false(tmp_path):
+    setup_repo(tmp_path)
+    assert detect_changes(tmp_path) is False
+


### PR DESCRIPTION
## Summary
- detect changes across README and data files
- only open refresh PR when data changed
- show dirty files for debugging
- document update logic
- add unit test for change detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c51d6e82c832a84e5640c25fe1289