### PR TITLE
Add repo validation step

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -41,6 +41,8 @@ jobs:
         run: python -m agentic_index_cli.scraper --min-stars $MIN_STARS
       - name: Enrich factors
         run: python -m agentic_index_cli.enricher data/repos.json
+      - name: Validate data
+        run: python -m agentic_index_cli.quality.validate data/repos.json
       - name: Rank repositories
         run: python -m agentic_index_cli.ranker data/repos.json
       - name: Run tests

--- a/agentic_index_cli/quality/validate.py
+++ b/agentic_index_cli/quality/validate.py
@@ -1,0 +1,55 @@
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft7Validator, ValidationError
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "schemas" / "repo.schema.json"
+
+
+def load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def validate_file(path: str) -> list:
+    data = json.loads(Path(path).read_text())
+    schema = load_schema()
+    validator = Draft7Validator(schema)
+    if not isinstance(data, list):
+        raise ValidationError("Data must be a list of repositories")
+    validated = {}
+    duplicates = []
+    for repo in data:
+        validator.validate(repo)
+        name = repo.get("full_name")
+        if name in validated:
+            prev = validated[name]
+            prev_score = prev.get("AgenticIndexScore", 0)
+            new_score = repo.get("AgenticIndexScore", 0)
+            if new_score > prev_score:
+                duplicates.append(prev)
+                validated[name] = repo
+            else:
+                duplicates.append(repo)
+        else:
+            validated[name] = repo
+    if duplicates:
+        names = ", ".join(r.get("full_name", "?") for r in duplicates)
+        raise ValidationError(f"duplicate entries: {names}")
+    return list(validated.values())
+
+
+def main(argv=None) -> int:
+    argv = argv or sys.argv[1:]
+    json_path = argv[0] if argv else "data/repos.json"
+    try:
+        validate_file(json_path)
+    except ValidationError as e:
+        print(f"ValidationError: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 PyYAML
 pytest-socket
 responses
+jsonschema>=3.2

--- a/schemas/repo.schema.json
+++ b/schemas/repo.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Repository",
+  "type": "object",
+  "required": [
+    "full_name",
+    "stargazers_count",
+    "forks_count",
+    "open_issues_count",
+    "pushed_at",
+    "license",
+    "owner"
+  ],
+  "properties": {
+    "full_name": {"type": "string"},
+    "stargazers_count": {"type": "integer", "minimum": 0},
+    "forks_count": {"type": "integer", "minimum": 0},
+    "open_issues_count": {"type": "integer", "minimum": 0},
+    "pushed_at": {"type": "string", "format": "date-time"},
+    "license": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "properties": {"spdx_id": {"type": ["string", "null"]}},
+          "required": ["spdx_id"],
+          "additionalProperties": true
+        }
+      ]
+    },
+    "owner": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "properties": {"login": {"type": ["string", "null"]}},
+          "required": ["login"],
+          "additionalProperties": true
+        }
+      ]
+    }
+  },
+  "additionalProperties": true
+}

--- a/tests/test_validation_dup.py
+++ b/tests/test_validation_dup.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+
+
+def test_validation_dup(tmp_path):
+    repo_a = {
+        "full_name": "owner/repo",
+        "stargazers_count": 10,
+        "forks_count": 1,
+        "open_issues_count": 0,
+        "pushed_at": "2025-01-01T00:00:00Z",
+        "license": {"spdx_id": "MIT"},
+        "owner": {"login": "owner"},
+        "AgenticIndexScore": 1,
+    }
+    repo_b = dict(repo_a)
+    repo_b["AgenticIndexScore"] = 2
+    data = [repo_a, repo_b]
+    path = tmp_path / "repos.json"
+    path.write_text(json.dumps(data))
+    result = subprocess.run(
+        ["python", "-m", "agentic_index_cli.quality.validate", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "duplicate entries" in result.stderr
+

--- a/tests/test_validation_ok.py
+++ b/tests/test_validation_ok.py
@@ -1,0 +1,23 @@
+import json
+import subprocess
+
+
+def test_validation_ok(tmp_path):
+    repo = {
+        "full_name": "owner/repo",
+        "stargazers_count": 10,
+        "forks_count": 1,
+        "open_issues_count": 0,
+        "pushed_at": "2025-01-01T00:00:00Z",
+        "license": {"spdx_id": "MIT"},
+        "owner": {"login": "owner"},
+    }
+    path = tmp_path / "repos.json"
+    path.write_text(json.dumps([repo]))
+    result = subprocess.run(
+        ["python", "-m", "agentic_index_cli.quality.validate", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+


### PR DESCRIPTION
## Summary
- define repo schema
- add validator module and integrate with rank pipeline
- run validator in update workflow
- add tests for validator
- add jsonschema dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c5a923144832a9495c9dd20f3d0b9