### PR TITLE
Add large file LFS guard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.png filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           pip install pytest-socket
           pytest --disable-socket -q 2>&1 | tee pytest.log
           python scripts/network_guard.py pytest.log
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: detect-large-files
 
   check_critical_tasks:
     name: Check for Outstanding Critical Review Tasks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,10 @@ repos:
         entry: pytest --quiet --cov=agentic_index_cli
         language: system
         files: \.py$
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+        name: detect-large-files
+        args: [--maxkb=5120]
+        exclude: ^data/history/.*\.json\.gz$

--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ Check out [CONTRIBUTING.md](./CONTRIBUTING.md) for how to:
   * Flag outdated info or errors.
   * Suggest tweaks to scoring or categories.
   * Understand what makes a repo eligible.
+  * Install [Git LFS](https://git-lfs.github.com/) and run `git lfs install`.
+    PNG and GIF assets are tracked via LFS.
 
 For tips on keeping your branch in sync with `main` and resolving conflicts, see
 [CONFLICT_RESOLUTION.md](./docs/CONFLICT_RESOLUTION.md).

--- a/docs/secrets-and-lfs.md
+++ b/docs/secrets-and-lfs.md
@@ -1,0 +1,23 @@
+# Secrets and Git LFS
+
+This project uses pre-commit hooks to prevent large or sensitive files from accidentally entering the repository. The `detect-large-files` hook blocks binaries over 5&nbsp;MB except for archived history data.
+
+## Installing Git LFS
+
+1. Install the Git LFS package for your platform. On Ubuntu:
+   ```bash
+   sudo apt-get install git-lfs
+   ```
+2. Enable it for your user account:
+   ```bash
+   git lfs install
+   ```
+
+## Files Tracked in LFS
+
+The repository automatically tracks these patterns via `.gitattributes`:
+
+- `*.png`
+- `*.gif`
+
+Git will store matching files as pointers, reducing clone size and avoiding large pushes.


### PR DESCRIPTION
## Summary
- add detect-large-files pre-commit hook
- run detect-large-files in CI workflow
- track png and gif via `.gitattributes`
- document Git LFS usage and tracked patterns
- mention Git LFS requirement in README

## Testing
- `pre-commit run detect-large-files --files README.md docs/secrets-and-lfs.md .pre-commit-config.yaml .github/workflows/ci.yml .gitattributes`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_684c5aaa6880832a8bcc51be81cf128a