### PR TITLE
Expose agentic_index_cli sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         run: pip install -r requirements.txt
       - name: Install package
         run: pip install -e .
+      - name: Verify import
+        run: python -c "import agentic_index_cli"
       - name: README sync check
         run: python scripts/inject_readme.py --check
       - name: Run regression guard
@@ -44,6 +46,8 @@ jobs:
         run: pip install -r requirements.txt
       - name: Install package
         run: pip install -e .
+      - name: Verify import
+        run: python -c "import agentic_index_cli"
       - name: Install pre-commit
         run: |
           pip install -i https://pypi.org/simple \

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,18 @@
+# Python cache and build artefacts
 __pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.eggs/
+.pytest_cache/
 .hypothesis/
 .coverage
+
+# Node packages
+node_modules/
 
 # Ignore generated trend plots
 /docs/trends/*.png
 # Ignore runtime JSON outputs
 repos.json
-
-__pycache__/
-*.pyc
-.pytest_cache/
-node_modules/
-agentic_index.egg-info/
-

--- a/agentic_index_cli/inject.py
+++ b/agentic_index_cli/inject.py
@@ -1,14 +1,17 @@
-"""Helpers for injecting the top-50 table into ``README.md``."""
+"""CLI for injecting the ranked table into the README."""
 
 from .internal.inject_readme import main
 
 
-def cli(argv=None):
+def cli(argv=None) -> None:
+    """Run the injector."""
     import argparse
-    parser = argparse.ArgumentParser(description="Inject README table")
+
+    parser = argparse.ArgumentParser(description="Synchronise README table")
     parser.add_argument("--force", action="store_true")
     args = parser.parse_args(argv)
     main(force=args.force)
+
 
 if __name__ == "__main__":
     cli()

--- a/agentic_index_cli/ranker.py
+++ b/agentic_index_cli/ranker.py
@@ -1,4 +1,13 @@
-from scripts.rank import main
+"""Command line interface for ranking repositories."""
+
+from .internal.rank import main
+
+
+def cli(argv=None) -> None:
+    """Run the ranking command."""
+    path = argv[0] if argv else "data/repos.json"
+    main(path)
 
 if __name__ == "__main__":
-    main()
+    import sys
+    cli(sys.argv[1:])

--- a/agentic_index_cli/scraper.py
+++ b/agentic_index_cli/scraper.py
@@ -1,4 +1,11 @@
-from scripts.scrape import main
+"""CLI entry point for scraping repositories."""
+
+from .internal.scrape import main
+
+
+def cli(argv=None) -> None:
+    """Run the scraper."""
+    main()
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
 [build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentic-index"
+version = "0.1.0"
+description = "CLI for Agentic Index"
+requires-python = ">=3.8"
+dependencies = [
+    "requests",
+    "PyYAML",
+    "jsonschema>=3.2",
+]
+
+[project.scripts]
+agentic-index = "agentic_index_cli.__main__:main"


### PR DESCRIPTION
## Summary
- publish `agentic_index_cli` sources for CLI
- define dependencies and entry point in `pyproject.toml`
- ignore build artefacts in `.gitignore`
- ensure GitHub Actions imports the package

## Testing
- `pip install -e .`
- `pytest -q`
- `python -c "import agentic_index_cli"`


------
https://chatgpt.com/codex/tasks/task_e_684cc514b928832a802e06c7dcb80f70