### PR TITLE
Add missing tests and tighten coverage gate

### DIFF
--- a/scripts/coverage_gate.py
+++ b/scripts/coverage_gate.py
@@ -1,7 +1,7 @@
 import sys
 import xml.etree.ElementTree as ET
 
-THRESHOLD = 49  # will auto-bump after next coverage uplift
+THRESHOLD = 80  # updated threshold for core logic tests
 
 
 def main(path: str = "coverage.xml") -> int:

--- a/tests/test_categorize_more.py
+++ b/tests/test_categorize_more.py
@@ -1,0 +1,8 @@
+import agentic_index_cli.agentic_index as ai
+
+
+def test_categorize_branches():
+    assert ai.categorize("dev toolkit", []) == "DevTools"
+    assert ai.categorize("Video processing", []) == "Domain-Specific"
+    assert ai.categorize("Experimental research", []) == "Experimental"
+    assert ai.categorize("Just another repo", []) == "General-purpose"

--- a/tests/test_cli_wrappers.py
+++ b/tests/test_cli_wrappers.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+# ensure project root for importing "scripts" package
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import agentic_index_cli.scraper as scraper
+import agentic_index_cli.ranker as ranker
+import agentic_index_cli.inject as inject
+import agentic_index_cli.generate_outputs as gen
+
+
+def test_scraper_cli(monkeypatch):
+    called = {}
+    def fake_main():
+        called['scrape'] = True
+    monkeypatch.setattr(scraper, 'main', fake_main)
+    scraper.cli([])
+    assert called.get('scrape')
+
+
+def test_ranker_cli(monkeypatch, tmp_path):
+    called = {}
+    def fake_main(path):
+        called['path'] = path
+    monkeypatch.setattr(ranker, 'main', fake_main)
+    ranker.cli([str(tmp_path/'repos.json')])
+    assert called['path'].endswith('repos.json')
+
+
+def test_inject_cli(monkeypatch):
+    called = {}
+    def fake_main(force=False):
+        called['force'] = force
+    monkeypatch.setattr(inject, 'main', fake_main)
+    inject.cli(['--force'])
+    assert called['force'] is True
+
+
+def test_generate_outputs(monkeypatch):
+    called = {}
+    def fake_inject(force=False):
+        called['force'] = force
+    monkeypatch.setattr(gen, 'inject', fake_inject)
+    gen.main(['--force'])
+    assert called['force'] is True

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,21 @@
+import agentic_index_cli.internal.scrape as scrape
+
+
+def test_extract():
+    item = {
+        "name": "repo",
+        "full_name": "owner/repo",
+        "html_url": "url",
+        "description": "d",
+        "stargazers_count": 1,
+        "forks_count": 2,
+        "open_issues_count": 3,
+        "archived": False,
+        "license": {"spdx_id": "MIT"},
+        "language": "Python",
+        "pushed_at": "2025-01-01T00:00:00Z",
+        "owner": {"login": "owner"},
+    }
+    data = scrape._extract(item)
+    assert data["full_name"] == "owner/repo"
+    assert data["license"]["spdx_id"] == "MIT"

--- a/tests/test_inject_markers.py
+++ b/tests/test_inject_markers.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import agentic_index_cli.internal.inject_readme as inj
+
+
+def test_missing_markers(tmp_path, monkeypatch):
+    readme = tmp_path / "README.md"
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "top50.md").write_text("| Rank | Repo | Score | Category |\n|------|------|-------|----------|\n")
+    readme.write_text("no table here")
+
+    monkeypatch.setattr(inj, "README_PATH", readme)
+    monkeypatch.setattr(inj, "DATA_PATH", data_dir / "top50.md")
+    assert inj.main() == 1

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import agentic_index_cli.__main__ as main
+import agentic_index_cli.agentic_index as ai
+
+
+def test_main_scrape(monkeypatch, tmp_path):
+    called = {}
+    def fake_run_index(min_stars, iterations, output):
+        called['args'] = (min_stars, iterations, output)
+    monkeypatch.setattr(ai, 'run_index', fake_run_index)
+    main.main(['scrape', '--min-stars', '1', '--iterations', '2', '--output', str(tmp_path)])
+    assert called['args'] == (1, 2, Path(tmp_path))

--- a/tests/test_run_index.py
+++ b/tests/test_run_index.py
@@ -1,0 +1,27 @@
+import csv
+from pathlib import Path
+import agentic_index_cli.agentic_index as ai
+
+
+def test_run_index_creates_outputs(tmp_path, monkeypatch):
+    data = [
+        {
+            "name": "repo",
+            "stars": 10,
+            "last_commit": "2025-06-01T00:00:00Z",
+            ai.SCORE_KEY: 1.0,
+            "category": "General",
+            "description": "desc",
+        }
+    ]
+    monkeypatch.setattr(ai, "search_and_harvest", lambda min_stars: data)
+    ai.run_index(min_stars=0, iterations=1, output=tmp_path)
+
+    assert (tmp_path / "top50.csv").exists()
+    assert (tmp_path / "top50.md").exists()
+    assert (tmp_path / "CHANGELOG.md").exists()
+
+    with open(tmp_path / "top50.csv") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+        assert rows and rows[0]["name"] == "repo"

--- a/tests/test_score_formula.py
+++ b/tests/test_score_formula.py
@@ -1,0 +1,31 @@
+import math
+import agentic_index_cli.agentic_index as ai
+
+
+def test_compute_score_formula():
+    repo = {
+        "stargazers_count": 100,
+        "open_issues_count": 2,
+        "closed_issues": 8,
+        "pushed_at": "2025-06-01T00:00:00Z",
+        "license": {"spdx_id": "MIT"},
+        "topics": ["tool"],
+    }
+    readme = "word " * 300 + "```code```"
+    score = ai.compute_score(repo, readme)
+
+    recency = ai.compute_recency_factor(repo["pushed_at"])
+    issue_health = ai.compute_issue_health(2, 8)
+    doc_comp = ai.readme_doc_completeness(readme)
+    license_free = ai.license_freedom("MIT")
+    eco = ai.ecosystem_integration(["tool"], readme)
+    expected = (
+        0.35 * math.log2(100 + 1)
+        + 0.20 * recency
+        + 0.15 * issue_health
+        + 0.15 * doc_comp
+        + 0.10 * license_free
+        + 0.05 * eco
+    )
+    expected = round(expected * 100 / 8, 2)
+    assert math.isclose(score, expected)

--- a/tests/test_search_pagination.py
+++ b/tests/test_search_pagination.py
@@ -1,0 +1,20 @@
+import agentic_index_cli.agentic_index as ai
+
+
+def test_search_and_harvest_pagination(monkeypatch):
+    calls = []
+    def fake_github_search(query, page):
+        calls.append(page)
+        return [{"full_name": f"repo{page}"}]
+
+    def fake_harvest_repo(name):
+        return {"name": name, ai.SCORE_KEY: 1}
+
+    monkeypatch.setattr(ai, "SEARCH_TERMS", ["term"])
+    monkeypatch.setattr(ai, "TOPIC_FILTERS", [])
+    monkeypatch.setattr(ai, "github_search", fake_github_search)
+    monkeypatch.setattr(ai, "harvest_repo", fake_harvest_repo)
+
+    repos = ai.search_and_harvest(min_stars=0, max_pages=3)
+    assert [r["name"] for r in repos] == ["repo1", "repo2", "repo3"]
+    assert calls == [1, 2, 3]


### PR DESCRIPTION
## Summary
- ensure CI fails below 80% coverage
- test search pagination logic
- verify score formula
- check README injection markers
- cover CLI wrappers and main entry point
- add helper tests for categorize and scraper internals

## Testing
- `pytest --cov=agentic_index_cli --cov-report=term -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc7150be4832aa779ceaaf5aa63ac