### PR TITLE
Add resilient GitHub scraper

### DIFF
--- a/agentic_index_cli/exceptions.py
+++ b/agentic_index_cli/exceptions.py
@@ -1,0 +1,11 @@
+class ScraperError(Exception):
+    """Base exception for scraper errors."""
+
+class APIError(ScraperError):
+    """API request failed."""
+
+class RateLimitError(ScraperError):
+    """GitHub API rate limit exceeded."""
+
+class InvalidRepoError(ScraperError):
+    """Repository data failed validation."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "requests",
     "PyYAML",
     "jsonschema>=3.2",
+    "pydantic",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyYAML
 pytest-socket
 responses
 jsonschema>=3.2
+pydantic

--- a/tests/test_scrape_errors.py
+++ b/tests/test_scrape_errors.py
@@ -1,0 +1,94 @@
+import json
+import time
+import responses
+import agentic_index_cli.internal.scrape as scrape
+
+
+@responses.activate
+def test_scrape_retry_500(monkeypatch):
+    item = {
+        "name": "repo",
+        "full_name": "owner/repo",
+        "html_url": "https://example.com/repo",
+        "description": "test repo",
+        "stargazers_count": 1,
+        "forks_count": 0,
+        "open_issues_count": 0,
+        "archived": False,
+        "license": {"spdx_id": "MIT"},
+        "language": "Python",
+        "pushed_at": "2025-01-01T00:00:00Z",
+        "owner": {"login": "owner"},
+    }
+    monkeypatch.setattr(scrape, "QUERIES", ["q"])
+    calls = {"n": 0}
+
+    def cb(request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return (500, {}, "")
+        return (
+            200,
+            {"X-RateLimit-Remaining": "1"},
+            json.dumps({"items": [item]}),
+        )
+
+    responses.add_callback(
+        responses.GET,
+        "https://api.github.com/search/repositories",
+        callback=cb,
+        match_querystring=False,
+    )
+    monkeypatch.setattr(scrape.time, "sleep", lambda s: None)
+    repos = scrape.scrape(0, token=None)
+    assert calls["n"] >= 2
+    assert repos[0]["full_name"] == "owner/repo"
+
+
+@responses.activate
+def test_scrape_rate_limit_sleep(monkeypatch):
+    monkeypatch.setattr(scrape, "QUERIES", ["q"])
+    sleeps = {"s": 0}
+
+    def fake_sleep(sec):
+        sleeps["s"] = sec
+
+    monkeypatch.setattr(scrape.time, "sleep", fake_sleep)
+
+    def cb(request):
+        if sleeps["s"] == 0:
+            return (
+                403,
+                {"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": str(int(time.time()) + 1)},
+                "",
+            )
+        return (
+            200,
+            {"X-RateLimit-Remaining": "1"},
+            json.dumps({"items": []}),
+        )
+
+    responses.add_callback(
+        responses.GET,
+        "https://api.github.com/search/repositories",
+        callback=cb,
+        match_querystring=False,
+    )
+
+    scrape.scrape(0, token=None)
+    assert sleeps["s"] > 0
+
+
+@responses.activate
+def test_scrape_bad_json(monkeypatch):
+    monkeypatch.setattr(scrape, "QUERIES", ["q"])
+    responses.add(
+        responses.GET,
+        "https://api.github.com/search/repositories",
+        body="not-json",
+        headers={"X-RateLimit-Remaining": "1"},
+        status=200,
+    )
+    repos = scrape.scrape(0, token=None)
+    assert repos == []
+


### PR DESCRIPTION
## Summary
- add custom scraper exceptions
- implement retry/backoff & rate-limit handling
- validate repo JSON via Pydantic
- use structured logging for scraper output
- test scraper behavior on API failures

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pytest --quiet --cov=agentic_index_cli`

------
https://chatgpt.com/codex/tasks/task_e_684ccb492870832a8e623fe865d6ffe8