### PR TITLE
Add security scanning jobs

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,31 @@
+name: pip-audit
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run pip-audit
+        uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266
+        with:
+          inputs: requirements.txt
+          format: sarif
+          output: pip-audit.sarif
+      - name: Upload pip-audit results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: pip-audit.sarif

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,26 @@
+name: TruffleHog Scan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run TruffleHog
+        uses: trufflesecurity/trufflehog@52d0ee5f5419ca938d3b7e358fe6f32131565026
+        with:
+          path: .
+          format: sarif
+          output: trufflehog-results.sarif
+      - name: Upload TruffleHog results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trufflehog-results.sarif

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Practices
+
+This project relies on GitHub Actions for automated checks. The
+`GITHUB_TOKEN` used by workflows should be limited to the permissions
+required for scanning and publishing results.
+
+## Token Scope
+
+For custom tokens, grant only `contents: read` and `security-events: write`.
+Avoid broader scopes unless absolutely necessary.
+
+## Rotation
+
+Rotate tokens at least every 90 days or immediately if exposure is
+suspected. Update the repository secrets with the new token and remove
+the old one.


### PR DESCRIPTION
## Summary
- add `pip-audit` job to detect vulnerable Python dependencies
- scan repo with TruffleHog for secrets
- explain token scope and rotation in `SECURITY.md`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q` *(fails: `TypeError` in tests with network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684cccdc78b8832a9c24b71669959a5b