### PR TITLE
Add development docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,23 @@ To run the scraping and ranking tools locally, install the CLI:
 pip install agentic-index-cli
 ```
 
+## Development environment
+
+Set up Python 3.11 and install dependencies:
+
+```bash
+pip install -r requirements.txt
+pip install -e .
+pip install pre-commit
+pre-commit install
+```
+
+Run the full test suite before pushing changes:
+
+```bash
+pytest -q
+```
+
 ## Working on Launch Readiness Review Issues
 
 A comprehensive project review was conducted in June 2025 to identify areas for improvement before launch. Findings from this review have been translated into actionable GitHub issues.

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Check out [CONTRIBUTING.md](./CONTRIBUTING.md) for how to:
   * Understand what makes a repo eligible.
   * Install [Git LFS](https://git-lfs.github.com/) and run `git lfs install`.
     PNG and GIF assets are tracked via LFS.
+  * Set up your dev environment with [DEVELOPMENT.md](./docs/DEVELOPMENT.md).
 
 For tips on keeping your branch in sync with `main` and resolving conflicts, see
 [CONFLICT_RESOLUTION.md](./docs/CONFLICT_RESOLUTION.md).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,46 @@
+# Development Guide
+
+This page explains how to set up a working environment for Agentic Index contributors.
+
+## Workflow
+
+```mermaid
+graph TD
+    A[Fork repository] --> B(Clone locally)
+    B --> C(Install dependencies)
+    C --> D(`pre-commit install`)
+    D --> E(Make changes)
+    E --> F(`pre-commit run --files <files>`)
+    F --> G(`pytest -q`)
+    G --> H(Push and open PR)
+```
+
+## Common commands
+
+```bash
+# install runtime deps
+pip install -r requirements.txt
+
+# install the package in editable mode
+pip install -e .
+
+# set up hooks and run lint/tests automatically
+pre-commit install
+
+# run the full test suite
+pytest -q
+```
+
+## Troubleshooting FAQ
+
+**Q: Network errors when installing packages?**
+
+Use the default PyPI mirror or the mirror in `docs/CI_SETUP.md` if your network blocks outbound HTTPS.
+
+**Q: GitHub API rate limit when scraping?**
+
+Export `GITHUB_TOKEN` with a personal token to increase limits or reduce the `--min-stars` argument when testing locally.
+
+**Q: Paths not recognized on Windows?**
+
+Run the tools in WSL or use forward slashes (e.g. `python scripts/inject_readme.py`).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
       - CI Audit Report: ci-audit.md
       - Conflict Resolution: CONFLICT_RESOLUTION.md
       - Coverage Baseline: coverage_baseline.md
+      - Development Setup: DEVELOPMENT.md
   - Methodology: METHODOLOGY.md
   - CLI Usage: cli.md
   - API Reference:


### PR DESCRIPTION
## Summary
- expand contributing guide with dev environment steps
- document development workflow in new docs/DEVELOPMENT.md
- update README contributing section to link to development docs
- add new docs page to MkDocs navigation

## Testing
- `SKIP=inject-readme pre-commit run --files docs/DEVELOPMENT.md CONTRIBUTING.md README.md mkdocs.yml`
- `pytest -q` *(fails: TypeError in scrape.py `>=` not supported)*

------
https://chatgpt.com/codex/tasks/task_e_684cce4041ec832aa8fca9a2a7b7337b