### PR TITLE
Fix regression guard false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: README sync check
         run: python scripts/inject_readme.py --check
       - name: Run regression guard
-        run: python scripts/regression_check.py
+        run: python scripts/regression_check.py --allowlist regression_allowlist.yml
       - name: Run tests with coverage
         run: pytest --cov=agentic_index_cli --cov-report=xml
         env:

--- a/agentic_index_cli/internal/regression_check.py
+++ b/agentic_index_cli/internal/regression_check.py
@@ -1,15 +1,20 @@
-
 """Fail CI if forbidden patterns appear in tracked files.
 
-Patterns to block/allow are configured in `.regression.yml`:
-  forbidden: list of substrings
-  allowed_regex: list of regex patterns that override a match
+Patterns to block/allow are configured in ``.regression.yml`` and an optional
+allowlist file. ``.regression.yml`` contains:
+
+``forbidden`` - list of substrings to search for
+``allowed_regex`` - regex patterns that override a match
+
+``regression_allowlist.yml`` provides regexes for lines that should be ignored
+entirely.
 """
 from __future__ import annotations
 import re
 import subprocess
 import sys
 from pathlib import Path
+import argparse
 import yaml
 
 CONFIG_PATH = Path('.regression.yml')
@@ -25,14 +30,44 @@ def load_config(path: Path = CONFIG_PATH) -> dict:
     return cfg
 
 
-def gather_files() -> list[Path]:
-    out = subprocess.check_output(['git', 'ls-files'], text=True)
-    files = [Path(p) for p in out.splitlines() if p]
-    return [p for p in files if p != CONFIG_PATH]
+DEFAULT_GLOBS = [
+    'agentic_index_cli/**/*.py',
+    'scripts/**/*.py',
+    'tests/**/*.py',
+    'docs/**/*.md',
+    'README.md',
+]
+
+ALLOWLIST_PATH = Path('regression_allowlist.yml')
+
+
+def load_allowlist(path: Path = ALLOWLIST_PATH) -> list[str]:
+    if not path.exists():
+        return []
+    with open(path, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f) or {}
+    return data.get('allow', [])
+
+
+def gather_files(globs: list[str] | None = None) -> list[Path]:
+    globs = globs or DEFAULT_GLOBS
+    files: list[Path] = []
+    for g in globs:
+        out = subprocess.check_output(['git', 'ls-files', g], text=True)
+        files.extend(Path(p) for p in out.splitlines() if p)
+    # deduplicate while preserving order
+    seen = set()
+    unique = []
+    for f in files:
+        if f not in seen:
+            seen.add(f)
+            unique.append(f)
+    return [p for p in unique if p != CONFIG_PATH]
 
 
 def check_files(paths: list[Path], config: dict) -> list[str]:
     allowed = [re.compile(p) for p in config.get('allowed_regex', [])]
+    allowlist = [re.compile(p) for p in config.get('allowlist', [])]
     forbidden = config.get('forbidden', [])
     failures = []
     for p in paths:
@@ -43,6 +78,8 @@ def check_files(paths: list[Path], config: dict) -> list[str]:
         except Exception:
             continue
         for lineno, line in enumerate(text.splitlines(), 1):
+            if any(r.search(line) for r in allowlist):
+                continue
             for pat in forbidden:
                 if pat in line:
                     if any(r.search(line) for r in allowed):
@@ -52,9 +89,20 @@ def check_files(paths: list[Path], config: dict) -> list[str]:
     return failures
 
 
-def main(paths: list[str] | None = None) -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--allowlist', type=Path, default=ALLOWLIST_PATH,
+                        help='YAML file containing allowed regex patterns')
+    parser.add_argument('--add-allow', action='append', default=[],
+                        dest='add_allow', help='Additional allowed regex')
+    parser.add_argument('paths', nargs='*', help='Files to check')
+    args = parser.parse_args(argv)
+
     cfg = load_config()
-    files = [Path(p) for p in paths] if paths else gather_files()
+    cfg['allowlist'] = load_allowlist(args.allowlist)
+    cfg['allowed_regex'].extend(args.add_allow)
+
+    files = [Path(p) for p in args.paths] if args.paths else gather_files()
     fails = check_files(files, cfg)
     if fails:
         print('Forbidden patterns found:')
@@ -63,5 +111,5 @@ def main(paths: list[str] | None = None) -> int:
         return 1
     return 0
 
-
-
+if __name__ == '__main__':
+    sys.exit(main())

--- a/docs/CONFLICT_RESOLUTION.md
+++ b/docs/CONFLICT_RESOLUTION.md
@@ -29,3 +29,14 @@ For `update.yml` to refresh the data automatically, GitHub Actions must be allow
 2. Comment `/rebase` on the PR.
 3. The bot opens a draft PR named `<original>-rebased` for review.
 
+## Regression guard exceptions
+
+If a forbidden word appears legitimately (for example in a snapshot or test),
+add a regex to `regression_allowlist.yml`. You can try a pattern locally with:
+
+```bash
+python scripts/regression_check.py --add-allow "<regex>"
+```
+
+Commit the updated allowlist so future runs pass.
+

--- a/regression_allowlist.yml
+++ b/regression_allowlist.yml
@@ -1,0 +1,3 @@
+allow:
+  - '^agentops$'
+  - '"score"\\s*:'

--- a/scripts/regression_check.py
+++ b/scripts/regression_check.py
@@ -1,68 +1,8 @@
 #!/usr/bin/env python3
-"""Fail CI if forbidden patterns appear in tracked files.
-
-Patterns to block/allow are configured in `.regression.yml`:
-  forbidden: list of substrings
-  allowed_regex: list of regex patterns that override a match
-"""
-from __future__ import annotations
-import re
-import subprocess
+"""Wrapper for internal regression guard."""
+from agentic_index_cli.internal.regression_check import main
 import sys
-from pathlib import Path
-import yaml
-
-CONFIG_PATH = Path('.regression.yml')
-
-
-def load_config(path: Path = CONFIG_PATH) -> dict:
-    if not path.exists():
-        return {"forbidden": [], "allowed_regex": []}
-    with open(path, 'r', encoding='utf-8') as f:
-        cfg = yaml.safe_load(f) or {}
-    cfg.setdefault('forbidden', [])
-    cfg.setdefault('allowed_regex', [])
-    return cfg
-
-
-def gather_files() -> list[Path]:
-    out = subprocess.check_output(['git', 'ls-files'], text=True)
-    files = [Path(p) for p in out.splitlines() if p]
-    return [p for p in files if p != CONFIG_PATH]
-
-
-def check_files(paths: list[Path], config: dict) -> list[str]:
-    allowed = [re.compile(p) for p in config.get('allowed_regex', [])]
-    forbidden = config.get('forbidden', [])
-    failures = []
-    for p in paths:
-        if p.resolve() == CONFIG_PATH.resolve():
-            continue
-        try:
-            text = p.read_text(encoding='utf-8', errors='ignore')
-        except Exception:
-            continue
-        for lineno, line in enumerate(text.splitlines(), 1):
-            for pat in forbidden:
-                if pat in line:
-                    if any(r.search(line) for r in allowed):
-                        break
-                    failures.append(f'{p}:{lineno}: {pat}')
-                    break
-    return failures
-
-
-def main(paths: list[str] | None = None) -> int:
-    cfg = load_config()
-    files = [Path(p) for p in paths] if paths else gather_files()
-    fails = check_files(files, cfg)
-    if fails:
-        print('Forbidden patterns found:')
-        for f in fails:
-            print(f)
-        return 1
-    return 0
-
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main())
+

--- a/tests/test_regression_check.py
+++ b/tests/test_regression_check.py
@@ -1,23 +1,32 @@
 import agentic_index_cli.internal.regression_check as rc
 
 
-def test_regression_allows_external_agentops(tmp_path):
-    bad = "agentops" + "_cli"
+def test_regression_allows_snapshot_mentions(tmp_path):
     cfg = tmp_path / '.regression.yml'
-    cfg.write_text(f'forbidden:\n  - {bad}\nallowed_regex:\n  - https://github\\.com/.*/agentops\\b\n')
-    f = tmp_path / 'sample.txt'
-    f.write_text('check https://github.com/foo/agentops for more')
+    cfg.write_text('forbidden:\n  - agentops\nallowed_regex: []\n')
+    allow = tmp_path / 'regression_allowlist.yml'
+    allow.write_text("allow:\n  - '^agentops$'\n  - '\"score\"\\s*:'\n")
 
-    failures = rc.check_files([f], rc.load_config(cfg))
+    f = tmp_path / 'data' / 'snap.json'
+    f.parent.mkdir()
+    f.write_text('agentops')
+
+    config = rc.load_config(cfg)
+    config['allowlist'] = rc.load_allowlist(allow)
+    failures = rc.check_files([f], config)
     assert not failures
 
 
 def test_regression_blocks_internal(tmp_path):
-    bad = "agentops" + "_cli"
     cfg = tmp_path / '.regression.yml'
-    cfg.write_text(f'forbidden:\n  - {bad}\nallowed_regex: []\n')
-    f = tmp_path / 'mod.py'
-    f.write_text(f'import {bad}')
+    cfg.write_text('forbidden:\n  - agentops\nallowed_regex: []\n')
+    allow = tmp_path / 'regression_allowlist.yml'
+    allow.write_text("allow:\n  - '^agentops$'\n  - '\"score\"\\s*:'\n")
 
-    failures = rc.check_files([f], rc.load_config(cfg))
+    f = tmp_path / 'mod.py'
+    f.write_text('import agentops')
+
+    config = rc.load_config(cfg)
+    config['allowlist'] = rc.load_allowlist(allow)
+    failures = rc.check_files([f], config)
     assert failures


### PR DESCRIPTION
## Summary
- tune regression check allowlist logic and CLI
- add `regression_allowlist.yml`
- scope scanning to source, tests, docs and README
- update CI step and docs
- adjust regression guard tests

## Testing
- `pytest -q`
- `python scripts/regression_check.py --allowlist regression_allowlist.yml`
- `python scripts/regression_check.py --allowlist regression_allowlist.yml tmp_violation.py` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_684cd6258464832a9522087709872c77