### PR TITLE
ci: publish /web site to GitHub Pages

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -13,6 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: |
+          cd web
+          npm ci
+          npm run build
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          publish_dir: web/dist
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Want a shortcut? Jump to the [Fast-Start table](FAST_START.md).
 <a href="https://github.com/adrianwedd/Agentic-Index/actions/workflows/ci.yml"><img src="badges/build.svg" alt="build"></a>
 <a href="badges/coverage.svg"><img src="badges/coverage.svg" alt="coverage"></a>
 <a href="https://adrianwedd.github.io/Agentic-Index/"><img src="badges/docs.svg" alt="docs"></a>
+<a href="https://adrianwedd.github.io/Agentic-Index/"><img src="https://img.shields.io/website?down_message=offline&up_message=online&url=https%3A%2F%2Fadrianwedd.github.io%2FAgentic-Index" alt="Site"></a>
 <a href="./LICENSE.md"><img src="badges/license.svg" alt="license"></a>
 <a href="https://pypi.org/project/agentic-index-cli/"><img src="badges/pypi.svg" alt="PyPI"></a>
 </p>


### PR DESCRIPTION
## Summary
- build the static web site before docs deployment
- publish `web/dist` to `gh-pages`
- show a live-site badge in the README

## Testing
- `python scripts/inject_readme.py --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd95cfbc0832ab32696d0d9d1f9b6