### PR TITLE
Replace dict() with model_dump()

### DIFF
--- a/agentic_index_cli/internal/scrape.py
+++ b/agentic_index_cli/internal/scrape.py
@@ -89,7 +89,7 @@ def _extract(item: Dict[str, Any]) -> Dict[str, Any]:
         repo = RepoModel(**item)
     except ValidationError as e:
         raise InvalidRepoError(str(e)) from e
-    data = repo.dict()
+    data = repo.model_dump()
     data["license"] = {"spdx_id": (repo.license.spdx_id if repo.license else None)}
     data["owner"] = {"login": repo.owner.login}
     return {field: data.get(field) for field in FIELDS}

--- a/agentic_index_cli/validate.py
+++ b/agentic_index_cli/validate.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 from typing import List
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, ConfigDict
 
 
 class License(BaseModel):
@@ -44,16 +44,14 @@ class Repo(BaseModel):
     last_commit: str | None = None
     one_liner: str | None = None
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class RepoFile(BaseModel):
     schema_version: int = 1
     repos: List[Repo]
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 def _migrate_item(item: dict) -> dict:
@@ -88,7 +86,7 @@ def load_repos(path: Path) -> List[dict]:
             duplicates.append(name)
             continue
         seen.add(name)
-        repos.append(repo.dict(exclude_none=True))
+        repos.append(repo.model_dump(exclude_none=True))
     if duplicates:
         dup = ", ".join(duplicates)
         raise ValidationError(f"duplicate entries: {dup}")
@@ -96,7 +94,7 @@ def load_repos(path: Path) -> List[dict]:
 
 
 def save_repos(path: Path, repos: List[dict]) -> None:
-    payload = RepoFile(repos=[Repo(**_migrate_item(r)) for r in repos]).dict(exclude_none=True)
+    payload = RepoFile(repos=[Repo(**_migrate_item(r)) for r in repos]).model_dump(exclude_none=True)
     path.write_text(json.dumps(payload, indent=2) + "\n")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "requests",
     "PyYAML",
     "jsonschema>=3.2",
-    "pydantic",
+    "pydantic>=2",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ PyYAML
 pytest-socket
 responses
 jsonschema>=3.2
-pydantic
+pydantic>=2


### PR DESCRIPTION
## Summary
- replace deprecated `dict()` with `model_dump()`
- use new `ConfigDict` syntax to suppress Pydantic warnings
- require pydantic>=2 in project metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cec0e7e74832a8e98c2c5559ec4b8