### PR TITLE
ci: automate release notes with release-drafter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+      - "fix"
     assignees:
       - "adrianwedd"
     reviewers:
@@ -16,6 +17,7 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+      - "fix"
     assignees:
       - "adrianwedd"
     reviewers:
@@ -26,6 +28,7 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+      - "ci"
     assignees:
       - "adrianwedd"
     reviewers:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,14 @@
+name-template: "v$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
+categories:
+  - title: "✨ Features"
+    labels: ["feature", "enhancement"]
+  - title: "🐛 Fixes"
+    labels: ["bug", "fix"]
+  - title: "🏗 CI"
+    labels: ["ci"]
+  - title: "📚 Docs"
+    labels: ["docs"]
+change-template: "- $TITLE by @$AUTHOR in #$NUMBER"
+include-labels: []
+exclude-labels: ["skip-changelog"]

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Draft Release Notes
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ To propose additions or changes:
 1. Fork the repo and create your branch.
 1. Make your changes with clear commits.
 1. Open a pull request describing what you changed.
+1. Tag your PR with `feature`, `enhancement`, `bug`, `fix`, `ci`, or `docs` so it appears in the release notes.
 
 We welcome fixes to data, new repo suggestions, and other improvements.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Want a shortcut? Jump to the [Fast-Start table](FAST_START.md).
 <a href="https://adrianwedd.github.io/Agentic-Index/"><img src="https://img.shields.io/website?down_message=offline&up_message=online&url=https%3A%2F%2Fadrianwedd.github.io%2FAgentic-Index" alt="Site"></a>
 <a href="./LICENSE.md"><img src="badges/license.svg" alt="license"></a>
 <a href="https://pypi.org/project/agentic-index-cli/"><img src="badges/pypi.svg" alt="PyPI"></a>
+<a href="https://github.com/adrianwedd/Agentic-Index/releases"><img src="https://img.shields.io/github/release/adrianwedd/Agentic-Index?include_prereleases" alt="Release Notes"></a>
 </p>
 
 This catalogue is maintained by the Agentic-Index project and is updated regularly (aiming for monthly refreshes) to reflect the rapidly evolving landscape of Agentic-AI.


### PR DESCRIPTION
## Summary
- automate release notes via release-drafter
- label dependabot PRs as ci or fix
- document PR label guidelines
- show release badge in README

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md .github/workflows/release-drafter.yml .github/release-drafter.yml .github/dependabot.yml`

------
https://chatgpt.com/codex/tasks/task_e_684cf288465c832ab53f2654993ff83f