### PR TITLE
ci: add shell keys to behind-check action

### DIFF
--- a/.github/actions/behind-check/action.yml
+++ b/.github/actions/behind-check/action.yml
@@ -2,14 +2,8 @@ name: behind-check
 runs:
   using: composite
   steps:
-    - run: git fetch --depth=0 origin "$GITHUB_HEAD_REF" "main"
-    - id: compare
-      run: |
-        behind=$(git rev-list --left-right --count origin/$GITHUB_HEAD_REF...origin/main | awk '{print $2}')
-        echo "behind=$behind" >> "$GITHUB_OUTPUT"
-    - run: |
-        if [ "${{ steps.compare.outputs.behind }}" -gt 0 ]; then
-          echo "Branch is behind main by ${{ steps.compare.outputs.behind }} commits" >&2
-          exit 1
-        fi
+    - shell: bash
+      run: echo "Checking branch status…"
+    - name: Run branch-behind check
       shell: bash
+      run: ./scripts/behind_check.sh

--- a/scripts/behind_check.sh
+++ b/scripts/behind_check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Check if current branch is behind main by more than 0 commits
+set -euo pipefail
+
+# Ensure repository is up-to-date
+# Expect GITHUB_HEAD_REF environment variable to be set to current branch
+
+git fetch origin "$GITHUB_HEAD_REF" "main"
+behind=$(git rev-list --left-right --count origin/$GITHUB_HEAD_REF...origin/main | awk '{print $2}')
+if [ "$behind" -gt 0 ]; then
+  echo "Branch is behind main by $behind commits" >&2
+  exit 1
+fi

--- a/tests/test_behind_check.sh
+++ b/tests/test_behind_check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Minimal test for scripts/behind_check.sh
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "$0")/.." && pwd)"
+
+repo=$(mktemp -d)
+cd "$repo"
+
+git init -b main >/dev/null
+
+touch file
+git add file
+git commit -m "init" >/dev/null
+
+# create feature branch and commit
+git checkout -b feature >/dev/null
+echo test > file
+git commit -am "feature" >/dev/null
+
+# commit on main to make feature behind
+git checkout main >/dev/null
+echo main > new
+git add new
+git commit -m "main" >/dev/null
+
+git remote add origin .
+
+export GITHUB_HEAD_REF=feature
+
+if "$root_dir/scripts/behind_check.sh"; then
+  echo "Expected failure when branch is behind" >&2
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary
- fix behind-check composite action by adding shell declarations
- add behind_check.sh script and minimal test

## Testing
- `bash tests/test_behind_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf3debd24832abb978a7fe0e8b573