### PR TITLE
ci: repair trufflehog SARIF upload

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -14,13 +14,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run TruffleHog
+      - name: Run TruffleHog on PR diff
+        if: ${{ github.event_name == 'pull_request' }}
         uses: trufflesecurity/trufflehog@52d0ee5f5419ca938d3b7e358fe6f32131565026
         with:
           path: .
-          format: sarif
-          output: trufflehog-results.sarif
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
+          extra_args: |
+            --format sarif
+            --output trufflehog-results.sarif
+      - name: Run TruffleHog on push
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: trufflesecurity/trufflehog@52d0ee5f5419ca938d3b7e358fe6f32131565026
+        with:
+          path: .
+          extra_args: |
+            --format sarif
+            --output trufflehog-results.sarif
       - name: Upload TruffleHog results
+        if: ${{ always() && hashFiles('trufflehog-results.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trufflehog-results.sarif


### PR DESCRIPTION
## Summary
- update TruffleHog workflow to use `extra_args`
- use `base`/`head` when scanning PR diffs
- upload SARIF only if the file exists

## Testing
- `actionlint .github/workflows/trufflehog.yml`
- `pytest -q`
- `act -j scan -W .github/workflows/trufflehog.yml -n` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684cf5999b98832aacb03d32ef07b5d1