### PR TITLE
Refactor behind-check to warn when behind

### DIFF
--- a/scripts/behind_check.sh
+++ b/scripts/behind_check.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
-# Check if current branch is behind main by more than 0 commits
 set -euo pipefail
 
-# Ensure repository is up-to-date
-# Expect GITHUB_HEAD_REF environment variable to be set to current branch
+echo "🔍 Checking if the branch is behind 'main'..."
 
-git fetch origin "$GITHUB_HEAD_REF" "main"
-behind=$(git rev-list --left-right --count origin/$GITHUB_HEAD_REF...origin/main | awk '{print $2}')
-if [ "$behind" -gt 0 ]; then
-  echo "Branch is behind main by $behind commits" >&2
-  exit 1
+git fetch origin main
+behind_count=$(git rev-list --count HEAD..origin/main)
+
+if [ "$behind_count" -gt 0 ]; then
+    echo "⚠️  Branch is behind 'main' by $behind_count commits."
+    if [[ "${GITHUB_OUTPUT:-}" ]]; then
+        echo "behind=true" >> "$GITHUB_OUTPUT"
+        echo "behind_count=$behind_count" >> "$GITHUB_OUTPUT"
+    fi
+    echo "ℹ️  Continuing without failure."
+else
+    echo "✅ Branch is up to date with 'main'."
+    if [[ "${GITHUB_OUTPUT:-}" ]]; then
+        echo "behind=false" >> "$GITHUB_OUTPUT"
+        echo "behind_count=0" >> "$GITHUB_OUTPUT"
+    fi
 fi

--- a/tests/test_behind_check.sh
+++ b/tests/test_behind_check.sh
@@ -26,11 +26,11 @@ git commit -m "main" >/dev/null
 
 git remote add origin .
 
-export GITHUB_HEAD_REF=feature
+git checkout feature >/dev/null
 
-if "$root_dir/scripts/behind_check.sh"; then
-  echo "Expected failure when branch is behind" >&2
-  exit 1
-else
-  exit 0
-fi
+export GITHUB_HEAD_REF=feature
+output_file=$(mktemp)
+export GITHUB_OUTPUT="$output_file"
+"$root_dir/scripts/behind_check.sh"
+
+grep -q 'behind=true' "$output_file"


### PR DESCRIPTION
## Summary
- adjust `behind_check.sh` to warn instead of exiting with an error
- update the shell test to verify the new behaviour

## Testing
- `bash tests/test_behind_check.sh`
- `CI_OFFLINE=1 pytest -q` *(fails: ModuleNotFoundError / network access)*

------
https://chatgpt.com/codex/tasks/task_e_684cf8458a38832a8fe69f4a3dd550a7