### PR TITLE
Fix pip-audit workflow tag

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Dependency audit
-        uses: pypa/gh-action-pip-audit@v1.1.4
+        uses: pypa/gh-action-pip-audit@v1.0.0
         with:
           inputs: requirements.txt
           format: json


### PR DESCRIPTION
## Summary
- point `pypa/gh-action-pip-audit` to `v1.0.0`

## Testing
- `pre-commit run --files .github/workflows/pip-audit.yml`
- `pytest -q --disable-socket`


------
https://chatgpt.com/codex/tasks/task_e_684cf7a485e4832a8565de215c51f5ad