### PR TITLE
Fix TruffleHog workflow version

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Secret scan with TruffleHog
-        uses: trufflesecurity/trufflehog/actions/scan@v3
+        uses: trufflesecurity/trufflehog/actions/scan@v3.75.0
         with:
           path: .
           base: ${{ github.event.before }}


### PR DESCRIPTION
## Summary
- pin TruffleHog action to the latest release tag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d01209bc4832a8dac5bdd4c726d2f