### PR TITLE
Fix pip-audit SARIF error

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -22,9 +22,10 @@ jobs:
       - name: Install pip-audit
         run: pip install pip-audit
       - name: Run pip-audit
-        run: pip-audit -r requirements.txt -f sarif -o pip-audit.sarif
-      - name: Upload SARIF
-        if: ${{ hashFiles('pip-audit.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v3
+        run: pip-audit -r requirements.txt -f json -o pip-audit.json
+      - name: Upload audit report
+        if: ${{ hashFiles('pip-audit.json') != '' }}
+        uses: actions/upload-artifact@v4
         with:
-          sarif_file: pip-audit.sarif
+          name: pip-audit.json
+          path: pip-audit.json


### PR DESCRIPTION
## Summary
- update CI pipeline to output pip-audit results as JSON
- store JSON audit report as a build artifact

## Testing
- `pre-commit run --files .github/workflows/pip-audit.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0218bb24832a94e251ff4ed4dc90