### PR TITLE
Add tests to raise coverage

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,3 +11,9 @@ def test_cli_help(tmp_path):
     assert result.returncode == 0
     assert 'scrape' in result.stdout
     assert 'faststart' in result.stdout
+
+
+def test_python_m_entrypoint():
+    result = subprocess.run([sys.executable, '-m', 'agentic_index_cli', '--help'], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert 'scrape' in result.stdout

--- a/tests/test_coverage_gate.py
+++ b/tests/test_coverage_gate.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from scripts.coverage_gate import main
+
+
+def _write_xml(tmp_path: Path, rate: float) -> Path:
+    p = tmp_path / "coverage.xml"
+    p.write_text(f'<coverage line-rate="{rate}"></coverage>')
+    return p
+
+
+def test_gate_pass(tmp_path):
+    xml = _write_xml(tmp_path, 0.81)
+    assert main(str(xml)) == 0
+
+
+def test_gate_fail(tmp_path):
+    xml = _write_xml(tmp_path, 0.79)
+    assert main(str(xml)) == 1

--- a/tests/test_fetch_badge.py
+++ b/tests/test_fetch_badge.py
@@ -36,3 +36,23 @@ def test_fetch_badge_404_creates_placeholder(tmp_path, monkeypatch):
     fetch_badge("http://example.com", dest)
     assert dest.exists()
     assert "<svg" in dest.read_text()
+
+
+def test_fetch_badge_urlerror(tmp_path, monkeypatch):
+    dest = tmp_path / "badge.svg"
+
+    def boom(url):
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    fetch_badge("http://example.com", dest)
+    assert dest.exists()
+    assert dest.read_text().startswith("<svg")
+
+
+def test_fetch_badge_offline_env(tmp_path, monkeypatch):
+    dest = tmp_path / "badge.svg"
+    monkeypatch.setenv("CI_OFFLINE", "1")
+    fetch_badge("http://example.com", dest)
+    assert dest.exists()
+    assert dest.read_text().startswith("<svg")

--- a/tests/test_fmt_delta.py
+++ b/tests/test_fmt_delta.py
@@ -1,0 +1,16 @@
+import pytest
+from agentic_index_cli.internal.inject_readme import _fmt_delta
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        (0, ""),
+        (5, "+5"),
+        (-3, "-3"),
+        (1.25, "+1.2"),
+        ("foo", "foo"),
+    ],
+)
+def test_fmt_delta(val, expected):
+    assert _fmt_delta(val) == expected

--- a/tests/test_inject_readme_unit.py
+++ b/tests/test_inject_readme_unit.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import json
+import agentic_index_cli.internal.inject_readme as inj
+
+
+def _setup(tmp_path: Path) -> Path:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "repos.json").write_text(
+        json.dumps({"schema_version": 1, "repos": [{"name": "x", "full_name": "o/x", "AgenticIndexScore": 1.0, "stars": 1, "category": "cat"}]})
+    )
+    (data_dir / "top50.md").write_text(
+        "| Rank | Repo | Score | ▲ StarsΔ | ▲ ScoreΔ | Category |\n|-----:|------|------:|-------:|--------:|----------|\n| 1 | x | 1.00 | +0 | +0 | cat |\n"
+    )
+    (data_dir / "last_snapshot.json").write_text('[{"name":"x","AgenticIndexScore":1.0,"stars":1}]')
+    readme = tmp_path / "README.md"
+    readme.write_text("start\n<!-- TOP50:START -->\nold\n<!-- TOP50:END -->\nend\n")
+
+    for name, val in {
+        "README_PATH": readme,
+        "DATA_PATH": data_dir / "top50.md",
+        "REPOS_PATH": data_dir / "repos.json",
+        "SNAPSHOT": data_dir / "last_snapshot.json",
+    }.items():
+        setattr(inj, name, val)
+    return readme
+
+
+def test_inject_and_check(tmp_path, monkeypatch):
+    readme = _setup(tmp_path)
+
+    assert inj.main() == 0
+    text = readme.read_text()
+    assert "| 1 | x | 1.00 |" in text
+
+    assert inj.main(check=True) == 0
+
+
+def test_check_fails_when_outdated(tmp_path, monkeypatch):
+    readme = _setup(tmp_path)
+    # write incorrect content
+    readme.write_text("start\n<!-- TOP50:START -->\nfoo\n<!-- TOP50:END -->\nend\n")
+    assert inj.main(check=True) == 1

--- a/tests/test_link_utils.py
+++ b/tests/test_link_utils.py
@@ -1,0 +1,14 @@
+import pytest
+from agentic_index_cli.internal.link_integrity import slug
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Hello World", "hello-world"),
+        ("Üñîçødé", "d"),
+        ("Spaces  and---Symbols!", "spaces-and---symbols"),
+    ],
+)
+def test_slug(text, expected):
+    assert slug(text) == expected


### PR DESCRIPTION
## Summary
- cover more error conditions in `fetch_badge`
- add unit tests for README injection logic
- test `coverage_gate` script
- add slug helper tests and `_fmt_delta` edge cases
- smoke test CLI module

## Testing
- `pytest -q --cov=. --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_684d02d27ff8832ab8e6bd8102fb391a