### PR TITLE
Fix TruffleHog composite action reference

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Secret scan with TruffleHog
-        uses: trufflesecurity/trufflehog/actions/scan@v3.75.0
+        uses: trufflesecurity/trufflehog/actions/scan@main
         with:
           path: .
           base: ${{ github.event.before }}


### PR DESCRIPTION
## Summary
- update the TruffleHog workflow to reference the `main` branch of the composite action

## Testing
- `pre-commit run --files .github/workflows/trufflehog.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d05d318b8832a87102a03f7501ad2