### PR TITLE
Fix README injector and badge tests

### DIFF
--- a/agentic_index_cli/internal/inject_readme.py
+++ b/agentic_index_cli/internal/inject_readme.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pathlib
 import sys
 import json
+import difflib
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -76,27 +77,12 @@ def _fmt_delta(val: str | int | float, *, is_int: bool = False) -> str:
         return val
 
 
-def main(*, force: bool = False, check: bool = False, write: bool = True) -> int:
-    """Synchronise the README table.
-
-    Parameters
-    ----------
-    force:
-        Write the README even if no changes detected.
-    check:
-        If ``True``, do not write. Exit ``1`` if README would change.
-    write:
-        Whether to update ``README.md``. Defaults to ``True``.
-    """
-
+def build_readme() -> str:
+    """Return README text with the top50 table injected."""
     readme_text = README_PATH.read_text(encoding="utf-8")
     end_newline = readme_text.endswith("\n")
-    try:
-        start_idx = readme_text.index(START)
-        end_idx = readme_text.index(END, start_idx)
-    except ValueError:
-        print("Markers not found in README.md", file=sys.stderr)
-        return 1
+    start_idx = readme_text.index(START)
+    end_idx = readme_text.index(END, start_idx)
 
     before = readme_text[: start_idx + len(START)].rstrip()
     after = "\n" + readme_text[end_idx + len(END) :].lstrip()
@@ -119,14 +105,54 @@ def main(*, force: bool = False, check: bool = False, write: bool = True) -> int
     new_text = new_text.rstrip("\n")
     if end_newline:
         new_text += "\n"
+    return new_text
+
+
+def diff(new_text: str, readme_path: pathlib.Path | None = None) -> str:
+    """Return a unified diff comparing ``new_text`` with ``readme_path``."""
+    if readme_path is None:
+        readme_path = README_PATH
+    old_text = readme_path.read_text(encoding="utf-8")
+    if not new_text.endswith("\n"):
+        new_text += "\n"
+    if not old_text.endswith("\n"):
+        old_text += "\n"
+    return "".join(
+        difflib.unified_diff(
+            old_text.splitlines(keepends=True),
+            new_text.splitlines(keepends=True),
+            fromfile=str(readme_path),
+            tofile="generated",
+        )
+    )
+
+
+def main(*, force: bool = False, check: bool = False, write: bool = True) -> int:
+    """Synchronise the README table.
+
+    Parameters
+    ----------
+    force:
+        Write the README even if no changes detected.
+    check:
+        If ``True``, do not write. Exit ``1`` if README would change.
+    write:
+        Whether to update ``README.md``. Defaults to ``True``.
+    """
+
+    try:
+        new_text = build_readme()
+    except ValueError:
+        print("Markers not found in README.md", file=sys.stderr)
+        return 1
 
     if check:
-        if new_text != readme_text:
+        if diff(new_text):
             print("README.md is out of date", file=sys.stderr)
             return 1
         return 0
 
-    if write and (force or new_text != readme_text):
+    if write and (force or diff(new_text)):
         README_PATH.write_text(new_text, encoding="utf-8")
 
     return 0

--- a/tests/test_fetch_badge.py
+++ b/tests/test_fetch_badge.py
@@ -1,22 +1,17 @@
 import urllib.error
 import urllib.request
 from pathlib import Path
+import io
 
 from agentic_index_cli.internal.rank import fetch_badge
 
 
-class DummyResp:
-    def __init__(self, data: bytes):
-        self.data = data
-
+class DummyResp(io.BytesIO):
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(self, *exc):
         pass
-
-    def read(self) -> bytes:
-        return self.data
 
 
 def test_fetch_badge_success(tmp_path, monkeypatch):

--- a/tests/test_inject_dry_run.py
+++ b/tests/test_inject_dry_run.py
@@ -21,4 +21,5 @@ def test_inject_readme_check(tmp_path, monkeypatch):
     monkeypatch.setattr(inj, "REPOS_PATH", data_dir / "repos.json")
     monkeypatch.setattr(inj, "SNAPSHOT", data_dir / "last_snapshot.json")
 
-    assert inj.main(check=True) == 0
+    modified = inj.build_readme()
+    assert inj.diff(modified) == ""


### PR DESCRIPTION
## Summary
- add context-manager behaviour to badge downloader test double
- expose `build_readme` and `diff` helpers for README injection
- refactor `main` to reuse helpers
- assert README diff emptiness in dry-run test

## Testing
- `pre-commit run --files agentic_index_cli/internal/inject_readme.py tests/test_fetch_badge.py tests/test_inject_dry_run.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d081ef144832ab642ecf254f5bdc1