### PR TITLE
Fix TruffleHog action path

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -15,14 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Secret scan with TruffleHog
-        uses: trufflesecurity/trufflehog/actions/scan@main
+        uses: trufflesecurity/trufflehog@main
         with:
           path: .
           base: ${{ github.event.before }}
           head: ${{ github.sha }}
-          scanArguments: --format sarif --output trufflehog-results.sarif
+          scanArguments: --format json --output trufflehog-results.json
       - name: Upload TruffleHog results
-        if: ${{ always() && hashFiles('trufflehog-results.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v3
+        if: ${{ always() && hashFiles('trufflehog-results.json') != '' }}
+        uses: actions/upload-artifact@v4
         with:
-          sarif_file: trufflehog-results.sarif
+          name: trufflehog-results
+          path: trufflehog-results.json


### PR DESCRIPTION
## Summary
- fix trufflehog action path
- output JSON instead of SARIF until upstream supports it
- upload artifact instead of SARIF file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684d0d72a5cc832a8c365e982db46ae0