### PR TITLE
Fix badge test fixture

### DIFF
--- a/tests/test_fetch_badge.py
+++ b/tests/test_fetch_badge.py
@@ -16,9 +16,10 @@ class DummyResp(io.BytesIO):
 
 def test_fetch_badge_success(tmp_path, monkeypatch):
     dest = tmp_path / "badge.svg"
-    monkeypatch.setattr(urllib.request, "urlopen", lambda url: DummyResp(b"<svg>ok</svg>"))
+    svg_ok = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+    monkeypatch.setattr(urllib.request, "urlopen", lambda url: DummyResp(svg_ok))
     fetch_badge("http://example.com", dest)
-    assert dest.read_bytes() == b"<svg>ok</svg>"
+    assert dest.read_bytes() == svg_ok
 
 
 def test_fetch_badge_404_creates_placeholder(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- use a realistic SVG snippet in `test_fetch_badge_success`

## Testing
- `pytest tests/test_fetch_badge.py::test_fetch_badge_success -q`
- `pytest -k fetch_badge -q`

------
https://chatgpt.com/codex/tasks/task_e_684d11286ff0832aa66b3a68a329b6e7