### PR TITLE
Implement repo scraping CLI with history

### DIFF
--- a/agentic_index_cli/validate.py
+++ b/agentic_index_cli/validate.py
@@ -24,7 +24,7 @@ class Repo(BaseModel):
     open_issues_count: int | None = None
     closed_issues: int | None = None
     archived: bool | None = None
-    license: License | None = None
+    license: License | str | None = None
     language: str | None = None
     pushed_at: str | None = None
     owner: Owner | None = None
@@ -43,6 +43,11 @@ class Repo(BaseModel):
     stars_log2: float | None = None
     last_commit: str | None = None
     one_liner: str | None = None
+    stars_30d: int | None = None
+    maintenance: float | None = None
+    docs_score: float | None = None
+    ecosystem: float | None = None
+    last_release: str | None = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/scripts/scrape_repos.py
+++ b/scripts/scrape_repos.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Scrape GitHub repository metadata for Agentic Index."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+from pathlib import Path
+from typing import Dict, Any, List
+
+import requests
+
+from agentic_index_cli.validate import save_repos
+
+HEADERS = {"Accept": "application/vnd.github+json"}
+TOKEN = os.getenv("GITHUB_TOKEN")
+if TOKEN:
+    HEADERS["Authorization"] = f"token {TOKEN}"
+
+DEFAULT_REPOS = ["octocat/Hello-World"]
+HIST_DIR = Path("data/hist")
+
+
+def _get(url: str) -> requests.Response:
+    resp = requests.get(url, headers=HEADERS)
+    resp.raise_for_status()
+    return resp
+
+
+def _compute_stars_30d(full_name: str, stars: int) -> int:
+    HIST_DIR.mkdir(parents=True, exist_ok=True)
+    today = _dt.date.today()
+    back = today - _dt.timedelta(days=30)
+    prev_file = HIST_DIR / f"{back.isoformat()}.json"
+    prev_stars = 0
+    if prev_file.exists():
+        try:
+            prev_data = json.loads(prev_file.read_text())
+            prev_stars = int(prev_data.get(full_name, 0))
+        except Exception:
+            prev_stars = 0
+    delta = stars - prev_stars
+
+    today_file = HIST_DIR / f"{today.isoformat()}.json"
+    cur = {}
+    if today_file.exists():
+        try:
+            cur = json.loads(today_file.read_text())
+        except Exception:
+            cur = {}
+    cur[full_name] = stars
+    today_file.write_text(json.dumps(cur, indent=2) + "\n")
+    return delta
+
+
+def fetch_repo(full_name: str) -> Dict[str, Any]:
+    repo_resp = _get(f"https://api.github.com/repos/{full_name}")
+    repo = repo_resp.json()
+    release_resp = requests.get(
+        f"https://api.github.com/repos/{full_name}/releases/latest",
+        headers=HEADERS,
+    )
+    last_release = None
+    if release_resp.status_code == 200:
+        try:
+            last_release = release_resp.json().get("published_at")
+        except Exception:
+            last_release = None
+
+    stars = repo.get("stargazers_count", 0)
+    topics = repo.get("topics", [])
+
+    data = {
+        "name": repo.get("name"),
+        "full_name": repo.get("full_name"),
+        "html_url": repo.get("html_url"),
+        "description": repo.get("description"),
+        "stargazers_count": stars,
+        "forks_count": repo.get("forks_count"),
+        "open_issues_count": repo.get("open_issues_count"),
+        "archived": repo.get("archived"),
+        "license": repo.get("license", {}).get("spdx_id"),
+        "language": repo.get("language"),
+        "pushed_at": repo.get("pushed_at"),
+        "owner": {"login": repo.get("owner", {}).get("login")},
+        "stars_30d": _compute_stars_30d(full_name, stars),
+        "maintenance": 1.0,
+        "docs_score": 0.0,
+        "ecosystem": 1.0 if topics else 0.0,
+        "last_release": last_release,
+    }
+    return data
+
+
+def scrape(repos: List[str]) -> List[Dict[str, Any]]:
+    results = []
+    for r in repos:
+        try:
+            results.append(fetch_repo(r))
+        except Exception as e:
+            print(f"Failed to fetch {r}: {e}")
+    return results
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Scrape GitHub repos")
+    parser.add_argument("--one-shot", action="store_true", help="fetch once")
+    parser.add_argument("--repos", nargs="*", default=DEFAULT_REPOS)
+    args = parser.parse_args(argv)
+
+    repos = scrape(args.repos)
+    Path("data").mkdir(exist_ok=True)
+    save_repos(Path("data/repos.json"), repos)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scrape_repos.py
+++ b/tests/test_scrape_repos.py
@@ -1,0 +1,57 @@
+import importlib.util
+import sys
+import json
+from pathlib import Path
+from unittest import mock
+
+# ensure project root on path for script imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+spec = importlib.util.spec_from_file_location('scraper', Path('scripts/scrape_repos.py'))
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+
+def make_response(data, status=200):
+    resp = mock.Mock()
+    resp.status_code = status
+    resp.json.return_value = data
+    resp.headers = {}
+    resp.raise_for_status = mock.Mock()
+    return resp
+
+
+def test_one_shot_fields(tmp_path, monkeypatch):
+    repo = {
+        "name": "repo",
+        "full_name": "owner/repo",
+        "html_url": "https://example.com",
+        "description": "desc",
+        "stargazers_count": 10,
+        "forks_count": 1,
+        "open_issues_count": 0,
+        "archived": False,
+        "license": {"spdx_id": "MIT"},
+        "language": "Python",
+        "pushed_at": "2025-06-01T00:00:00Z",
+        "owner": {"login": "owner"},
+        "topics": ["tool"],
+    }
+    release = {"published_at": "2025-05-01T00:00:00Z"}
+
+    def fake_get(url, headers=None):
+        if url.endswith('/repos/owner/repo'):
+            return make_response(repo)
+        if url.endswith('/repos/owner/repo/releases/latest'):
+            return make_response(release)
+        raise AssertionError(url)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(scraper.requests, 'get', fake_get)
+    monkeypatch.setattr(scraper, 'DEFAULT_REPOS', ['owner/repo'])
+    scraper.main(['--one-shot'])
+
+    data = json.loads((tmp_path / 'data/repos.json').read_text())
+    repo_data = data['repos'][0]
+    for field in ['stars_30d', 'maintenance', 'docs_score', 'ecosystem', 'last_release']:
+        assert field in repo_data


### PR DESCRIPTION
## Summary
- add new script `scripts/scrape_repos.py` for fetching GitHub repo metadata
- compute 30‑day star delta and cache star history
- extend pydantic Repo model with new schema fields
- add unit test mocking GitHub API to validate scraper fields

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d18af96a0832a93b357faf39e8d33