### PR TITLE
Add sorting flag to README injector

### DIFF
--- a/scripts/inject_readme.py
+++ b/scripts/inject_readme.py
@@ -4,14 +4,25 @@ from agentic_index_cli.internal.inject_readme import main
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Synchronise README top50 table")
+    class _Parser(argparse.ArgumentParser):
+        def error(self, message):
+            self.print_help()
+            self.exit(1)
+
+    parser = _Parser(description="Synchronise README top50 table")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--check", action="store_true", help="Fail if README is outdated")
     group.add_argument("--write", action="store_true", help="Update README in place (default)")
     group.add_argument("--dry-run", action="store_true", help="Alias for --check")
     parser.add_argument("--force", action="store_true", help="Write even if unchanged")
+    parser.add_argument(
+        "--sort-by",
+        default="score",
+        choices=["score", "stars_30d", "maintenance", "last_release"],
+        help="Sort table by metric",
+    )
     args = parser.parse_args()
 
     check = args.check or args.dry_run
     write = args.write or not check
-    main(force=args.force, check=check, write=write)
+    main(force=args.force, check=check, write=write, sort_by=args.sort_by)

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -1,0 +1,70 @@
+import json
+from pathlib import Path
+import agentic_index_cli.internal.inject_readme as inj
+import pytest
+
+
+def _setup(tmp_path: Path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    repos = [
+        {
+            "name": "A",
+            "full_name": "o/A",
+            "AgenticIndexScore": 1.0,
+            "stars_30d": 10,
+            "maintenance": 0.5,
+            "docs_score": 0.0,
+            "ecosystem": 0.0,
+            "last_release": "2025-06-01T00:00:00Z",
+            "license": "MIT",
+        },
+        {
+            "name": "B",
+            "full_name": "o/B",
+            "AgenticIndexScore": 2.0,
+            "stars_30d": 5,
+            "maintenance": 0.9,
+            "docs_score": 0.0,
+            "ecosystem": 0.0,
+            "last_release": "2025-05-01T00:00:00Z",
+            "license": "MIT",
+        },
+    ]
+    (data_dir / "repos.json").write_text(json.dumps({"schema_version": 2, "repos": repos}))
+    (data_dir / "top50.md").write_text("")
+    (data_dir / "last_snapshot.json").write_text("[]")
+    readme = tmp_path / "README.md"
+    readme.write_text("x\n<!-- TOP50:START -->\nold\n<!-- TOP50:END -->\n")
+
+    for name, val in {
+        "README_PATH": readme,
+        "DATA_PATH": data_dir / "top50.md",
+        "REPOS_PATH": data_dir / "repos.json",
+        "SNAPSHOT": data_dir / "last_snapshot.json",
+    }.items():
+        setattr(inj, name, val)
+    return readme
+
+
+@pytest.mark.parametrize(
+    "field,first",
+    [
+        ("score", "B"),
+        ("stars_30d", "A"),
+        ("maintenance", "B"),
+        ("last_release", "A"),
+    ],
+)
+def test_sort_order(tmp_path, field, first):
+    _setup(tmp_path)
+    text = inj.build_readme(sort_by=field)
+    lines = [l for l in text.splitlines() if l.startswith("|")][2:]
+    assert lines[0].split("|")[3].strip() == first
+
+
+def test_stable_between_runs(tmp_path):
+    _setup(tmp_path)
+    first = inj.build_readme(sort_by="stars_30d")
+    second = inj.build_readme(sort_by="stars_30d")
+    assert first == second


### PR DESCRIPTION
## Summary
- add `--sort-by` option to scripts/inject_readme.py
- support metric-based ordering in injector module
- include tests for sort field behaviour

## Testing
- `python -m pytest -q tests/test_sorting.py`
- `python scripts/inject_readme.py --sort-by stars_30d --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_684d2baf68a8832ab17bf2abe54faec0