### PR TITLE
Add repo scrape caching and rate-limit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ bash scripts/trigger_refresh.sh 75
 ```
 
 Replace `75` with your desired minimum star count. The script requires the GitHub CLI and an authenticated token.
+Set a personal access token via the `GITHUB_TOKEN_REPO_STATS` environment variable to avoid hitting rate limits when scraping.
 
 -----
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -39,7 +39,7 @@ Use the default PyPI mirror or the mirror in `docs/CI_SETUP.md` if your network 
 
 **Q: GitHub API rate limit when scraping?**
 
-Export `GITHUB_TOKEN` with a personal token to increase limits or reduce the `--min-stars` argument when testing locally.
+Export `GITHUB_TOKEN_REPO_STATS` with a personal token to increase limits or reduce the `--min-stars` argument when testing locally.
 
 **Q: Paths not recognized on Windows?**
 

--- a/scripts/inject_readme.py
+++ b/scripts/inject_readme.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from agentic_index_cli.internal.inject_readme import main
 
 if __name__ == "__main__":

--- a/tests/test_scrape_repos_cache.py
+++ b/tests/test_scrape_repos_cache.py
@@ -1,0 +1,42 @@
+import importlib.util
+import json
+import time
+from pathlib import Path
+from unittest import mock
+
+# load script module
+spec = importlib.util.spec_from_file_location('scraper', Path('scripts/scrape_repos.py'))
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+
+def test_cache_hit(monkeypatch, tmp_path):
+    cache_dir = tmp_path / '.cache'
+    cache_dir.mkdir()
+    data = {'full_name': 'owner/repo'}
+    cache_file = cache_dir / 'repo_owner_repo.json'
+    cache_file.write_text(json.dumps(data))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(scraper, 'CACHE_DIR', cache_dir)
+    monkeypatch.setattr(scraper.requests, 'get', lambda *a, **k: (_ for _ in ()).throw(AssertionError('no call')))
+    repo = scraper.fetch_repo('owner/repo')
+    assert repo['full_name'] == 'owner/repo'
+    assert scraper.CACHE_HITS == 1
+
+
+@mock.patch('time.sleep', lambda s: None)
+def test_rate_limit_backoff(monkeypatch):
+    resp1 = mock.Mock()
+    resp1.status_code = 403
+    resp1.headers = {'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': str(int(time.time()) + 1)}
+    resp1.raise_for_status = mock.Mock()
+    resp2 = mock.Mock()
+    resp2.status_code = 200
+    resp2.headers = {'X-RateLimit-Limit': '60', 'X-RateLimit-Remaining': '59'}
+    resp2.json.return_value = {}
+    resp2.raise_for_status = mock.Mock()
+    calls = iter([resp1, resp2])
+    monkeypatch.setattr(scraper.requests, 'get', lambda *a, **k: next(calls))
+    scraper._get('https://api.github.com/repos/owner/repo')
+    assert scraper.API_LIMIT == 60
+    assert scraper.API_REMAINING == 59


### PR DESCRIPTION
## Summary
- cache individual repo fetches to `.cache`
- handle GitHub rate limits with backoff
- output API usage summary
- document `GITHUB_TOKEN_REPO_STATS` token
- tests for cache hit and rate-limit logic

## Testing
- `pre-commit run --files README.md docs/DEVELOPMENT.md scripts/scrape_repos.py scripts/inject_readme.py tests/test_scrape_repos_cache.py`

------
https://chatgpt.com/codex/tasks/task_e_684d3c03d8a8832a9f184d97d35e659f