### PR TITLE
Improve README diff test with tolerance helper

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,88 @@
+import os
+import re
+import math
+from typing import List, Tuple, Dict, Any
+
+
+def _canonical(name: str) -> str:
+    name = re.sub(r"<[^>]+>", "", name)
+    name = re.sub(r"[^\w\s]+", "", name)
+    name = name.strip().lower()
+    mapping = {
+        "overall": "score",
+        "score": "score",
+        "repo": "repo",
+        "stars gained in last 30 days": "stars",
+        "stars d30d": "stars",
+        "stars": "stars",
+        "maint": "maint",
+        "maintenance": "maint",
+        "release": "release",
+        "docs": "docs",
+        "fit": "fit",
+        "license": "license",
+        "rank": "rank",
+    }
+    return mapping.get(name, name)
+
+
+def _parse_table(text: str) -> Tuple[List[str], List[List[str]]]:
+    lines = [l.strip() for l in text.splitlines() if l.strip().startswith("|")]
+    if not lines:
+        return [], []
+    headers = [c.strip() for c in lines[0].strip("|").split("|")]
+    rows = []
+    for line in lines[2:]:
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) != len(headers):
+            raise AssertionError(f"Column count mismatch in line: {line}")
+        rows.append(cells)
+    return headers, rows
+
+
+def _parse_value(cell: str) -> Tuple[Any, str]:
+    if re.fullmatch(r"-?\d+", cell):
+        return int(cell), "int"
+    if re.fullmatch(r"-?\d+\.\d+", cell):
+        return float(cell), "float"
+    return cell, "text"
+
+
+def _load_tolerances(tols: Dict[str, float] | None) -> Dict[str, float]:
+    result = {}
+    if tols:
+        result.update({_canonical(k): float(v) for k, v in tols.items()})
+    env = os.getenv("README_TOLERANCES")
+    if env:
+        for part in env.split(","):
+            if not part.strip():
+                continue
+            key, val = part.split("=", 1)
+            result[_canonical(key)] = float(val)
+    return result
+
+
+def assert_readme_equivalent(expected: str, actual: str, tolerances: Dict[str, float] | None = None) -> None:
+    tols = _load_tolerances(tolerances)
+    exp_headers_raw, exp_rows = _parse_table(expected)
+    act_headers_raw, act_rows = _parse_table(actual)
+    assert exp_headers_raw == act_headers_raw, "Header mismatch"
+    assert len(exp_rows) == len(act_rows), "Row count changed"
+    headers = exp_headers_raw
+    for row_idx, (erow, arow) in enumerate(zip(exp_rows, act_rows)):
+        assert len(erow) == len(arow), f"Column count changed in row {row_idx}"
+        for col_idx, (ecell, acell) in enumerate(zip(erow, arow)):
+            header = headers[col_idx]
+            key = _canonical(header)
+            val1, kind1 = _parse_value(ecell)
+            val2, kind2 = _parse_value(acell)
+            if kind1 == "text" or kind2 == "text":
+                assert ecell == acell, f"Mismatch in row {row_idx} column {header}"
+                continue
+            tol = tols.get(key, 0.0)
+            if kind1 == "int" and kind2 == "int" and "." not in ecell and "." not in acell:
+                assert abs(val1 - val2) <= tol, f"Int mismatch in row {row_idx} column {header}: {val1} vs {val2}"
+            else:
+                assert math.isclose(float(val1), float(val2), rel_tol=tol), (
+                    f"Float mismatch in row {row_idx} column {header}: {val1} vs {val2} tol={tol}"
+                )

--- a/tests/test_inject_dry_run.py
+++ b/tests/test_inject_dry_run.py
@@ -1,15 +1,22 @@
+import sys
 import shutil
 from pathlib import Path
 
+import re
+import pytest
+
+# ensure project root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import agentic_index_cli.internal.inject_readme as inj
-from _utils import assert_readme_diff
+from helpers import assert_readme_equivalent
 
 
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_inject_readme_check(tmp_path, monkeypatch):
+def _setup(tmp_path, monkeypatch):
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     shutil.copy(ROOT / "data" / "top50.md", data_dir / "top50.md")
@@ -28,6 +35,51 @@ def test_inject_readme_check(tmp_path, monkeypatch):
     monkeypatch.setattr(inj, "SNAPSHOT", data_dir / "last_snapshot.json")
 
     modified = inj.build_readme().strip()
-    assert_readme_diff(readme.read_text().strip(), modified)
+    return readme, modified
 
+
+def test_inject_readme_check(tmp_path, monkeypatch):
+    readme, modified = _setup(tmp_path, monkeypatch)
+    assert_readme_equivalent(readme.read_text().strip(), modified, {"score": 0.005})
     assert inj.main(check=True) == 0
+
+
+def _bump_score(text: str, delta: float) -> str:
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith("| 1 |"):
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
+            cells[1] = f"{float(cells[1]) + delta:.2f}"
+            lines[i] = "| " + " | ".join(cells) + " |"
+            break
+    return "\n".join(lines)
+
+
+def _change_cell(text: str, col: int, value: str) -> str:
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith("| 1 |"):
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
+            cells[col] = value
+            lines[i] = "| " + " | ".join(cells) + " |"
+            break
+    return "\n".join(lines)
+
+
+@pytest.mark.parametrize(
+    "modifier,should_pass",
+    [
+        (lambda txt: _bump_score(txt, 0.015), True),
+        (lambda txt: _bump_score(txt, 0.05), False),
+        (lambda txt: _change_cell(txt, 8, "MIT"), False),
+        (lambda txt: _change_cell(txt, 0, "2"), False),
+    ],
+)
+def test_readme_tolerances(tmp_path, monkeypatch, modifier, should_pass):
+    readme, modified = _setup(tmp_path, monkeypatch)
+    modified = modifier(modified)
+    if should_pass:
+        assert_readme_equivalent(readme.read_text().strip(), modified, {"score": 0.005})
+    else:
+        with pytest.raises(AssertionError):
+            assert_readme_equivalent(readme.read_text().strip(), modified, {"score": 0.005})


### PR DESCRIPTION
## Summary
- add a new helper `assert_readme_equivalent` that compares README tables with configurable tolerance
- replace strict diffing in `test_inject_dry_run` with the new helper
- parameterize tests to validate numeric tolerance and strict matching for text fields

## Testing
- `pytest tests/test_inject_dry_run.py tests/test_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3eaf5ee0832abedaa28530558856