### PR TITLE
Add docstrings across CLI modules

### DIFF
--- a/agentic_index_cli/__init__.py
+++ b/agentic_index_cli/__init__.py
@@ -1,1 +1,1 @@
-# Agentic Index CLI package
+"""Command-line interface for working with the Agentic Index."""

--- a/agentic_index_cli/__main__.py
+++ b/agentic_index_cli/__main__.py
@@ -1,8 +1,11 @@
+"""Entrypoint for the ``agentic-index`` command line tool."""
+
 import argparse
 from pathlib import Path
 
 
 def main(argv=None):
+    """Dispatch subcommands for the CLI."""
     parser = argparse.ArgumentParser(prog="agentic-index", description="Agentic Index CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
 

--- a/agentic_index_cli/enricher.py
+++ b/agentic_index_cli/enricher.py
@@ -1,4 +1,4 @@
-"""Enrichment utilities for repository metadata."""
+"""Helpers for enriching scraped repository data."""
 
 import argparse
 import math
@@ -13,12 +13,7 @@ from .validate import load_repos, save_repos
 
 
 def enrich(path: Path) -> None:
-    """Add derived fields to a repository JSON file.
-
-    Args:
-        path: Path to the repository JSON data.
-    """
-
+    """Add derived fields to a repository JSON file."""
     data = load_repos(path)
     for repo in data:
         stars = repo.get("stargazers_count", 0)
@@ -40,12 +35,7 @@ def enrich(path: Path) -> None:
 
 
 def main(argv=None):
-    """Command-line interface for :func:`enrich`.
-
-    Args:
-        argv: Optional command line arguments.
-    """
-
+    """Command-line interface for :func:`enrich`."""
     parser = argparse.ArgumentParser(description="Enrich scraped repo data")
     parser.add_argument("json_path", nargs="?", default="data/repos.json")
     args = parser.parse_args(argv)

--- a/agentic_index_cli/exceptions.py
+++ b/agentic_index_cli/exceptions.py
@@ -1,3 +1,6 @@
+"""Custom exception hierarchy for the Agentic Index scraper."""
+
+
 class ScraperError(Exception):
     """Base exception for scraper errors."""
 

--- a/agentic_index_cli/faststart.py
+++ b/agentic_index_cli/faststart.py
@@ -1,6 +1,7 @@
+"""Generate a FAST_START list of top repositories."""
+
 import argparse
 from pathlib import Path
-
 
 HEADER = (
     "| Rank | Repo (Click to Visit) | ★ Stars | Last Commit | Score | Category | One-Liner |\n"
@@ -9,12 +10,14 @@ HEADER = (
 
 
 def format_stars(stars: int) -> str:
+    """Return ``stars`` compacted for table display."""
     if stars >= 1000:
         return f"{stars/1000:.1f}k"
     return str(stars)
 
 
 def generate_table(repos):
+    """Return markdown table rows for ``repos``."""
     lines = [HEADER]
     for idx, repo in enumerate(repos, 1):
         repo_link = f"[{repo['full_name']}](https://github.com/{repo['full_name']})"
@@ -31,6 +34,7 @@ from .validate import load_repos
 
 
 def run(top: int, data_path: Path, output_path: Path | None = None) -> None:
+    """Write a FAST_START table for the highest scored repos."""
     repos = load_repos(data_path)
 
     filtered = [
@@ -50,6 +54,7 @@ def run(top: int, data_path: Path, output_path: Path | None = None) -> None:
 
 
 def main(argv=None):
+    """CLI wrapper for :func:`run`."""
     parser = argparse.ArgumentParser(description="Generate Fast Start table")
     parser.add_argument("--top", type=int, required=True, help="number of repos")
     parser.add_argument("data_path", help="path to repos.json")

--- a/agentic_index_cli/generate_outputs.py
+++ b/agentic_index_cli/generate_outputs.py
@@ -1,7 +1,10 @@
+"""Wrapper to generate markdown artifacts for the repository."""
+
 from scripts.inject_readme import main as inject
 
 
 def main(argv=None):
+    """Run the README injection helper."""
     import argparse
     parser = argparse.ArgumentParser(description="Generate markdown outputs")
     parser.add_argument("--force", action="store_true")

--- a/agentic_index_cli/helpers.py
+++ b/agentic_index_cli/helpers.py
@@ -1,6 +1,4 @@
 """Helper functions for Agentic Index."""
-
-
 def add(a: int, b: int) -> int:
     """Add two integers.
 
@@ -11,5 +9,4 @@ def add(a: int, b: int) -> int:
     Returns:
         The sum of ``a`` and ``b``.
     """
-
     return a + b

--- a/agentic_index_cli/inject_readme.py
+++ b/agentic_index_cli/inject_readme.py
@@ -4,6 +4,7 @@ from .internal.inject_readme import main
 
 
 def cli(argv=None):
+    """Entry point for the README injector."""
     import argparse
     parser = argparse.ArgumentParser(description="Inject README table")
     parser.add_argument("--force", action="store_true")

--- a/agentic_index_cli/internal/__init__.py
+++ b/agentic_index_cli/internal/__init__.py
@@ -1,0 +1,1 @@
+"""Internal helper modules for the Agentic Index CLI."""

--- a/agentic_index_cli/internal/deltas.py
+++ b/agentic_index_cli/internal/deltas.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Helpers for computing and formatting delta values."""
+
+from __future__ import annotations
 
 
 def _fmt_delta(old: int | None, new: int) -> str:

--- a/agentic_index_cli/internal/inject_readme.py
+++ b/agentic_index_cli/internal/inject_readme.py
@@ -170,7 +170,6 @@ def main(*, force: bool = False, check: bool = False, write: bool = True, sort_b
     sort_by:
         Field to sort by. One of ``score``, ``stars_30d``, ``maintenance``, or ``last_release``.
     """
-
     try:
         new_text = build_readme(sort_by=sort_by)
     except ValueError:

--- a/agentic_index_cli/internal/link_integrity.py
+++ b/agentic_index_cli/internal/link_integrity.py
@@ -1,5 +1,6 @@
-"""Check README and docs for broken internal links and badges."""
+"""Check Markdown links and badges for correctness."""
 from __future__ import annotations
+
 import re
 import sys
 from pathlib import Path
@@ -14,6 +15,7 @@ HTML_IMG_RE = re.compile(r'<img\s+[^>]*src="([^"]+)"')
 
 
 def slug(text: str) -> str:
+    """Return GitHub-style slug for ``text``."""
     s = re.sub(r'[\s]+', '-', re.sub(r'[^\x00-\x7F]+', '', text))
     s = re.sub(r'[^a-zA-Z0-9\- ]', '', s)
     s = s.replace(' ', '-')
@@ -21,6 +23,7 @@ def slug(text: str) -> str:
 
 
 def extract_headings(lines: Iterable[str]) -> set[str]:
+    """Return anchor IDs from markdown ``lines``."""
     anchors = set()
     for line in lines:
         m = HEAD_RE.match(line)
@@ -30,6 +33,7 @@ def extract_headings(lines: Iterable[str]) -> set[str]:
 
 
 def check_file(path: Path, headings: set[str], failures: list[str]) -> None:
+    """Validate links within ``path`` against ``headings``."""
     text = path.read_text(encoding="utf-8")
     for lineno, line in enumerate(text.splitlines(), 1):
         for anchor in ANCHOR_RE.findall(line):
@@ -45,6 +49,7 @@ def check_file(path: Path, headings: set[str], failures: list[str]) -> None:
 
 
 def http_ok(url: str) -> bool:
+    """Return ``True`` if ``url`` responds with status 200."""
     for _ in range(2):
         try:
             resp = requests.get(url, timeout=3)
@@ -56,6 +61,7 @@ def http_ok(url: str) -> bool:
 
 
 def main(paths: Iterable[str] | None = None) -> int:
+    """CLI entry for link and badge checks."""
     if paths is None:
         paths = ["README.md"] + [str(p) for p in Path("docs").glob("*.md")]
     failures: list[str] = []

--- a/agentic_index_cli/internal/rank.py
+++ b/agentic_index_cli/internal/rank.py
@@ -1,7 +1,5 @@
-
-"""
-Rank agentic-AI repos, write a Markdown table, and emit Shields.io badges
-showing the last sync date and today’s top-ranked repo.
+# -*- coding: utf-8 -*-
+"""Rank Agentic-AI repos and generate badges.
 
 Usage:
     python extend_rank.py [data/repos.json]
@@ -40,7 +38,6 @@ def compute_score(repo: dict) -> float:
             + 0.10 * license
             + 0.05 * ecosystem
     """
-
     stars = repo.get("stars", repo.get("stargazers_count", 0))
     recency = repo.get("recency_factor")
     if recency is None:
@@ -72,6 +69,7 @@ def compute_score(repo: dict) -> float:
 
 
 def infer_category(repo: dict) -> str:
+    """Derive a high-level category from repo metadata."""
     blob = (
         " ".join(repo.get("topics", []))
         + " "
@@ -115,6 +113,7 @@ def fetch_badge(url: str, dest: Path) -> None:
 
 
 def generate_badges(top_repo: str, iso_date: str, repo_count: int) -> None:
+    """Create Shields.io badges for the ranking results."""
     badges = Path("badges")
     badges.mkdir(exist_ok=True)
 
@@ -135,6 +134,7 @@ def generate_badges(top_repo: str, iso_date: str, repo_count: int) -> None:
 
 
 def main(json_path: str = "data/repos.json") -> None:
+    """Rank repositories and write results back to disk."""
     data_file = Path(json_path)
     is_test = os.getenv("PYTEST_CURRENT_TEST") is not None
     repos = load_repos(data_file)

--- a/agentic_index_cli/internal/regression_check.py
+++ b/agentic_index_cli/internal/regression_check.py
@@ -21,6 +21,7 @@ CONFIG_PATH = Path('.regression.yml')
 
 
 def load_config(path: Path = CONFIG_PATH) -> dict:
+    """Return regression config from ``path``."""
     if not path.exists():
         return {"forbidden": [], "allowed_regex": []}
     with open(path, 'r', encoding='utf-8') as f:
@@ -42,6 +43,7 @@ ALLOWLIST_PATH = Path('regression_allowlist.yml')
 
 
 def load_allowlist(path: Path = ALLOWLIST_PATH) -> list[str]:
+    """Load allowed regex patterns from ``path``."""
     if not path.exists():
         return []
     with open(path, 'r', encoding='utf-8') as f:
@@ -50,6 +52,7 @@ def load_allowlist(path: Path = ALLOWLIST_PATH) -> list[str]:
 
 
 def gather_files(globs: list[str] | None = None) -> list[Path]:
+    """Return repository files matching ``globs``."""
     globs = globs or DEFAULT_GLOBS
     files: list[Path] = []
     for g in globs:
@@ -66,6 +69,7 @@ def gather_files(globs: list[str] | None = None) -> list[Path]:
 
 
 def check_files(paths: list[Path], config: dict) -> list[str]:
+    """Return list of forbidden-pattern failures."""
     allowed = [re.compile(p) for p in config.get('allowed_regex', [])]
     allowlist = [re.compile(p) for p in config.get('allowlist', [])]
     forbidden = config.get('forbidden', [])
@@ -90,6 +94,7 @@ def check_files(paths: list[Path], config: dict) -> list[str]:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Command-line interface for regression checks."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--allowlist', type=Path, default=ALLOWLIST_PATH,
                         help='YAML file containing allowed regex patterns')

--- a/agentic_index_cli/internal/scrape.py
+++ b/agentic_index_cli/internal/scrape.py
@@ -1,3 +1,5 @@
+"""Scrape GitHub repositories for inclusion in the index."""
+
 import argparse
 import json
 import os
@@ -39,14 +41,20 @@ FIELDS = [
 
 
 class LicenseModel(BaseModel):
+    """Subset of repo license information."""
+
     spdx_id: str | None = None
 
 
 class OwnerModel(BaseModel):
+    """Repository owner information."""
+
     login: str | None = None
 
 
 class RepoModel(BaseModel):
+    """Model for GitHub repository objects."""
+
     name: str
     full_name: str
     html_url: str
@@ -96,6 +104,7 @@ def _extract(item: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def scrape(min_stars: int = 0, token: str | None = None) -> List[Dict[str, Any]]:
+    """Return repository metadata from GitHub."""
     global RATE_LIMIT_REMAINING
     headers = {"Accept": "application/vnd.github+json"}
     if token:
@@ -132,6 +141,7 @@ def scrape(min_stars: int = 0, token: str | None = None) -> List[Dict[str, Any]]
 
 
 def main() -> None:
+    """CLI wrapper for :func:`scrape`."""
     parser = argparse.ArgumentParser(description="Fetch GitHub repos for Agentic Index")
     parser.add_argument("--min-stars", type=int, default=0, dest="min_stars")
     args = parser.parse_args()

--- a/agentic_index_cli/plot_trends.py
+++ b/agentic_index_cli/plot_trends.py
@@ -1,6 +1,7 @@
 """Placeholder for future trend plotting logic."""
 
 def main() -> None:
+    """Print a placeholder message until implementation."""
     print("TrendGrapher is not yet implemented")
 
 if __name__ == "__main__":

--- a/agentic_index_cli/prune.py
+++ b/agentic_index_cli/prune.py
@@ -1,3 +1,5 @@
+"""Utilities for pruning stale repository data."""
+
 import argparse
 from datetime import datetime, timezone
 from pathlib import Path
@@ -10,14 +12,17 @@ from .validate import load_repos as _load, save_repos as _save
 
 
 def load_repos(path: Path = REPOS):
+    """Return repository data from ``path``."""
     return _load(path)
 
 
 def save_repos(repos, path: Path = REPOS):
+    """Write ``repos`` to ``path``."""
     _save(path, repos)
 
 
 def append_changelog(entries, changelog: Path = CHANGELOG):
+    """Append changelog ``entries`` to ``changelog`` file."""
     if not entries:
         return
     if changelog.exists():
@@ -30,6 +35,7 @@ def append_changelog(entries, changelog: Path = CHANGELOG):
 
 
 def prune(inactive_days, repos_path: Path = REPOS, changelog_path: Path = CHANGELOG):
+    """Remove repos inactive for ``inactive_days`` days."""
     repos = load_repos(repos_path)
     keep = []
     removed_entries = []
@@ -50,6 +56,7 @@ def prune(inactive_days, repos_path: Path = REPOS, changelog_path: Path = CHANGE
 
 
 def main(argv=None):
+    """CLI wrapper for :func:`prune`."""
     parser = argparse.ArgumentParser(description='Prune inactive repositories')
     parser.add_argument('--inactive', type=int, required=True, help='Days since last push')
     parser.add_argument('--repos-path', type=Path, default=REPOS)

--- a/agentic_index_cli/quality/__init__.py
+++ b/agentic_index_cli/quality/__init__.py
@@ -1,0 +1,1 @@
+"""Quality checking utilities for Agentic Index."""

--- a/agentic_index_cli/quality/validate.py
+++ b/agentic_index_cli/quality/validate.py
@@ -1,3 +1,5 @@
+"""Validate ``repos.json`` against the public schema."""
+
 import json
 import sys
 from pathlib import Path
@@ -9,10 +11,12 @@ SCHEMA_PATH = ROOT / "schemas" / "repo.schema.json"
 
 
 def load_schema() -> dict:
+    """Return the JSON schema used for validation."""
     return json.loads(SCHEMA_PATH.read_text())
 
 
 def validate_file(path: str) -> list:
+    """Validate ``path`` and return unique repos."""
     data = json.loads(Path(path).read_text())
     schema = load_schema()
     validator = Draft7Validator(schema)
@@ -41,6 +45,7 @@ def validate_file(path: str) -> list:
 
 
 def main(argv=None) -> int:
+    """CLI wrapper for :func:`validate_file`."""
     argv = argv or sys.argv[1:]
     json_path = argv[0] if argv else "data/repos.json"
     try:

--- a/agentic_index_cli/validate.py
+++ b/agentic_index_cli/validate.py
@@ -1,3 +1,5 @@
+"""Validation helpers for repository JSON files."""
+
 import json
 import sys
 from pathlib import Path
@@ -7,14 +9,20 @@ from pydantic import BaseModel, ValidationError, ConfigDict
 
 
 class License(BaseModel):
+    """Model for the ``license`` block."""
+
     spdx_id: str | None = None
 
 
 class Owner(BaseModel):
+    """Simplified repository owner model."""
+
     login: str | None = None
 
 
 class Repo(BaseModel):
+    """Repository schema used by :mod:`agentic_index_cli`."""
+
     name: str | None = None
     full_name: str | None = None
     html_url: str | None = None
@@ -53,6 +61,8 @@ class Repo(BaseModel):
 
 
 class RepoFile(BaseModel):
+    """Container for a list of :class:`Repo` objects."""
+
     schema_version: int = 2
     repos: List[Repo]
 
@@ -71,6 +81,7 @@ def _migrate_item(item: dict) -> dict:
 
 
 def load_repos(path: Path) -> List[dict]:
+    """Validate and load repository JSON data."""
     raw = json.loads(path.read_text())
     if isinstance(raw, list):
         items = raw
@@ -102,15 +113,18 @@ def load_repos(path: Path) -> List[dict]:
 
 
 def save_repos(path: Path, repos: List[dict]) -> None:
+    """Write validated ``repos`` to ``path``."""
     payload = RepoFile(repos=[Repo(**_migrate_item(r)) for r in repos]).model_dump(exclude_none=True)
     path.write_text(json.dumps(payload, indent=2) + "\n")
 
 
 def validate_file(path: str) -> List[dict]:
+    """Load and validate a repository JSON file."""
     return load_repos(Path(path))
 
 
 def main(argv=None) -> int:
+    """CLI entry for validating repo files."""
     argv = argv or sys.argv[1:]
     json_path = Path(argv[0] if argv else "data/repos.json")
     try:

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable utilities for the Agentic Index project."""


### PR DESCRIPTION
## Summary
- document CLI modules, internal helpers, and schemas
- ensure pydocstyle passes by adjusting docstring spacing and placement

## Testing
- `pydocstyle agentic_index_cli lib`
- `PYTHONPATH=. pytest --quiet --cov=agentic_index_cli` *(fails: AttributeError and network blocks)*

------
https://chatgpt.com/codex/tasks/task_e_684d4b837500832a97721f4747d2b6f4