### PR TITLE
Refine README table parsing

### DIFF
--- a/tests/test_parse_table_abbr.py
+++ b/tests/test_parse_table_abbr.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+# ensure project root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from helpers import _parse_table, assert_readme_equivalent
+
+
+def test_parse_table_strips_abbr():
+    table = (
+        "| Rank | <abbr title=\"Overall\">📊</abbr> Overall | Repo |\n"
+        "|-----:|------:|------|\n"
+        "| 1 | 1.0 | foo |\n"
+    )
+    headers, rows = _parse_table(table)
+    assert headers == ["Rank", "📊 Overall", "Repo"]
+    assert rows == [["1", "1.0", "foo"]]
+
+
+def test_assert_equivalent_ignores_abbr():
+    expected = (
+        "| Rank | <abbr title=\"Overall\">📊</abbr> Overall | Repo |\n"
+        "|-----:|------:|------|\n"
+        "| 1 | 1.0 | foo |\n"
+    )
+    actual = (
+        "| Rank | <abbr title='Overall'>📊</abbr> Overall | Repo |\n"
+        "|-----:|------:|------|\n"
+        "| 1 | 1.0 | foo |\n"
+    )
+    assert_readme_equivalent(expected, actual)


### PR DESCRIPTION
## Summary
- strip `<abbr>` tags when parsing tables
- improve diffs printed by `assert_readme_equivalent`
- add unit tests for abbr header handling

## Testing
- `pre-commit run --files tests/helpers.py tests/test_parse_table_abbr.py`
- `pytest tests/test_parse_table_abbr.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d4e37d024832a85fd1a528584434e