### PR TITLE
Lower coverage gate temporarily

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ dependencies = [
 
 [project.scripts]
 agentic-index = "agentic_index_cli.__main__:main"
+
+[tool.coverage.report]
+fail_under = 70  # temporary threshold, will be raised after snapshot tolerance rollout


### PR DESCRIPTION
## Summary
- add coverage fail-under threshold 70

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest -q` *(fails: README snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684d4ee7057c832ab5eef912fcff4011