### PR TITLE
Adjust score weightings

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The definitive list of Agentic-AI repositories, ranked by the Agentic Index Scor
 <details>
 <summary>📊 Metrics Legend</summary>
 
-- 📊 Score = 0.35*log2(stars+1) + 0.20*recency_factor + 0.15*issue_health + 0.15*doc_completeness + 0.10*license_freedom + 0.05*ecosystem_integration
+- 📊 Score = 0.30*log2(stars+1) + 0.25*recency_factor + 0.20*issue_health + 0.15*doc_completeness + 0.07*license_freedom + 0.03*ecosystem_integration
 - ⭐ Δ30d = stars gained in the last 30 days
 - 🔧 Maint = 1 / (days_since_last_commit * open_issue_ratio)
 - 📅 Release = 1 / days_since_last_release
@@ -207,7 +207,7 @@ Beyond the top-ranked, these projects are cooking up unique ideas, serving speci
 Agentic-Index believes in full transparency. Here’s the lowdown on how we find, vet, and score repositories.
 
 The core Agentic-Index Scoring Formula:
-`Score = 0.35*log2(stars+1) + 0.20*recency_factor + 0.15*issue_health + 0.15*doc_completeness + 0.10*license_freedom + 0.05*ecosystem_integration`\<sup\>†\</sup\>
+`Score = 0.30*log2(stars+1) + 0.25*recency_factor + 0.20*issue_health + 0.15*doc_completeness + 0.07*license_freedom + 0.03*ecosystem_integration`\<sup\>†\</sup\>
 
 \<sup\>†\</sup\> *Weights are reviewed and potentially tuned quarterly. Full math and reasoning in [`/docs/methodology.md`](./docs/methodology.md).*
 

--- a/agentic_index_cli/agentic_index.py
+++ b/agentic_index_cli/agentic_index.py
@@ -166,12 +166,12 @@ def compute_score(repo: Dict, readme: str) -> float:
     license_free = license_freedom(lic)
     eco = ecosystem_integration(repo.get("topics", []), readme)
     score = (
-        0.35 * math.log2(stars + 1)
-        + 0.20 * recency
-        + 0.15 * issue_health
+        0.30 * math.log2(stars + 1)
+        + 0.25 * recency
+        + 0.20 * issue_health
         + 0.15 * doc_comp
-        + 0.10 * license_free
-        + 0.05 * eco
+        + 0.07 * license_free
+        + 0.03 * eco
     )
     return round(score * 100 / 8, 2)  # normalized roughly to 0-100
 

--- a/agentic_index_cli/internal/rank.py
+++ b/agentic_index_cli/internal/rank.py
@@ -31,12 +31,12 @@ def compute_score(repo: dict) -> float:
 
     Equation::
 
-        S = 0.35 * log2(stars + 1)
-            + 0.20 * recency
-            + 0.15 * issue_health
+        S = 0.30 * log2(stars + 1)
+            + 0.25 * recency
+            + 0.20 * issue_health
             + 0.15 * docs
-            + 0.10 * license
-            + 0.05 * ecosystem
+            + 0.07 * license
+            + 0.03 * ecosystem
     """
     stars = repo.get("stars", repo.get("stargazers_count", 0))
     recency = repo.get("recency_factor")
@@ -58,12 +58,12 @@ def compute_score(repo: dict) -> float:
     ecosys = repo.get("ecosystem_integration", 0)
 
     score = (
-        0.35 * math.log2(stars + 1)
-        + 0.20 * recency
-        + 0.15 * issue_health
+        0.30 * math.log2(stars + 1)
+        + 0.25 * recency
+        + 0.20 * issue_health
         + 0.15 * docs
-        + 0.10 * license_free
-        + 0.05 * ecosys
+        + 0.07 * license_free
+        + 0.03 * ecosys
     )
     return round(score, 2)
 

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -21,10 +21,21 @@ def parse_delta(val: str):
         return num
 
 
+def _extract_table_lines(text: str) -> list[str]:
+    """Return only the table lines between the TOP50 markers."""
+    try:
+        start = text.index("<!-- TOP50:START -->")
+        end = text.index("<!-- TOP50:END -->", start)
+    except ValueError:
+        return [l for l in text.splitlines() if l.startswith("|")]
+    section = text[start:end]
+    return [l for l in section.splitlines() if l.startswith("|")]
+
+
 def assert_readme_diff(old: str, new: str, *, delta: float = 0.02) -> None:
     """Assert README tables differ only within ``delta`` for numeric cells."""
-    old_lines = [l for l in old.splitlines() if l.startswith("|")]
-    new_lines = [l for l in new.splitlines() if l.startswith("|")]
+    old_lines = _extract_table_lines(old)
+    new_lines = _extract_table_lines(new)
     assert len(old_lines) == len(new_lines)
     for i, (ol, nl) in enumerate(zip(old_lines, new_lines)):
         if i < 2:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -27,8 +27,19 @@ def _canonical(name: str) -> str:
     return mapping.get(name, name)
 
 
+def _extract_table(text: str) -> List[str]:
+    """Return table lines between the TOP50 markers if present."""
+    try:
+        start = text.index("<!-- TOP50:START -->")
+        end = text.index("<!-- TOP50:END -->", start)
+    except ValueError:
+        return [l.strip() for l in text.splitlines() if l.strip().startswith("|")]
+    section = text[start:end]
+    return [l.strip() for l in section.splitlines() if l.strip().startswith("|")]
+
+
 def _parse_table(text: str) -> Tuple[List[str], List[List[str]]]:
-    lines = [l.strip() for l in text.splitlines() if l.strip().startswith("|")]
+    lines = _extract_table(text)
     if not lines:
         return [], []
     raw_headers = [c.strip() for c in lines[0].strip("|").split("|")]

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -157,7 +157,7 @@ The definitive list of Agentic-AI repositories, ranked by the Agentic Index Scor
 <details>
 <summary>📊 Metrics Legend</summary>
 
-- 📊 Score = 0.35*log2(stars+1) + 0.20*recency_factor + 0.15*issue_health + 0.15*doc_completeness + 0.10*license_freedom + 0.05*ecosystem_integration
+- 📊 Score = 0.30*log2(stars+1) + 0.25*recency_factor + 0.20*issue_health + 0.15*doc_completeness + 0.07*license_freedom + 0.03*ecosystem_integration
 - ⭐ Δ30d = stars gained in the last 30 days
 - 🔧 Maint = 1 / (days_since_last_commit * open_issue_ratio)
 - 📅 Release = 1 / days_since_last_release
@@ -190,7 +190,7 @@ Beyond the top-ranked, these projects are cooking up unique ideas, serving speci
 Agentic-Index believes in full transparency. Here’s the lowdown on how we find, vet, and score repositories.
 
 The core Agentic-Index Scoring Formula:
-`Score = 0.35*log2(stars+1) + 0.20*recency_factor + 0.15*issue_health + 0.15*doc_completeness + 0.10*license_freedom + 0.05*ecosystem_integration`\<sup\>†\</sup\>
+`Score = 0.30*log2(stars+1) + 0.25*recency_factor + 0.20*issue_health + 0.15*doc_completeness + 0.07*license_freedom + 0.03*ecosystem_integration`\<sup\>†\</sup\>
 
 \<sup\>†\</sup\> *Weights are reviewed and potentially tuned quarterly. Full math and reasoning in [`/docs/methodology.md`](./docs/methodology.md).*
 

--- a/tests/test_score_formula.py
+++ b/tests/test_score_formula.py
@@ -20,12 +20,12 @@ def test_compute_score_formula():
     license_free = ai.license_freedom("MIT")
     eco = ai.ecosystem_integration(["tool"], readme)
     expected = (
-        0.35 * math.log2(100 + 1)
-        + 0.20 * recency
-        + 0.15 * issue_health
+        0.30 * math.log2(100 + 1)
+        + 0.25 * recency
+        + 0.20 * issue_health
         + 0.15 * doc_comp
-        + 0.10 * license_free
-        + 0.05 * eco
+        + 0.07 * license_free
+        + 0.03 * eco
     )
     expected = round(expected * 100 / 8, 2)
     assert math.isclose(score, expected)


### PR DESCRIPTION
## Summary
- tweak score formula weighting to better balance momentum vs. maintenance
- document updated formula in README and snapshot
- make README diff tests robust to extra tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d51023598832a962e422fab45743f