### PR TITLE
Fix newline handling in fetch_badge

### DIFF
--- a/agentic_index_cli/internal/rank.py
+++ b/agentic_index_cli/internal/rank.py
@@ -97,19 +97,20 @@ def fetch_badge(url: str, dest: Path) -> None:
     if os.getenv("CI_OFFLINE") == "1":
         if dest.exists():
             return
-        dest.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>\n')
+        dest.write_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"></svg>')
         return
     try:
         resp = urllib.request.urlopen(url)
         try:
-            dest.write_bytes(resp.read())
+            content = resp.read().rstrip(b"\n")
+            dest.write_bytes(content)
         finally:
             if hasattr(resp, "close"):
                 resp.close()
     except Exception:
         if dest.exists():
             return
-        dest.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>\n')
+        dest.write_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"></svg>')
 
 
 def generate_badges(top_repo: str, iso_date: str, repo_count: int) -> None:

--- a/tests/test_fetch_badge.py
+++ b/tests/test_fetch_badge.py
@@ -19,7 +19,7 @@ def test_fetch_badge_success(tmp_path, monkeypatch):
     svg_ok = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
     monkeypatch.setattr(urllib.request, "urlopen", lambda url: DummyResp(svg_ok))
     fetch_badge("http://example.com", dest)
-    assert dest.read_bytes() == svg_ok
+    assert dest.read_bytes().rstrip(b"\n") == svg_ok
 
 
 def test_fetch_badge_404_creates_placeholder(tmp_path, monkeypatch):
@@ -72,3 +72,11 @@ def test_fetch_badge_error_no_overwrite(tmp_path, monkeypatch):
     monkeypatch.setattr(urllib.request, "urlopen", boom)
     fetch_badge("http://example.com", dest)
     assert dest.read_text() == "old"
+
+
+def test_fetch_badge_strips_trailing_newline(tmp_path, monkeypatch):
+    dest = tmp_path / "badge.svg"
+    svg_ok = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+    monkeypatch.setattr(urllib.request, "urlopen", lambda url: DummyResp(svg_ok + b"\n"))
+    fetch_badge("http://example.com", dest)
+    assert dest.read_bytes() == svg_ok


### PR DESCRIPTION
## Summary
- normalise fetched badge bytes before writing
- relax badge test to ignore trailing newlines
- add regression test for newline variant

## Testing
- `pytest tests/test_fetch_badge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d535b9cc4832aaa4d2db065d19d14