### PR TITLE
Fix HTML stripping in table parser

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -42,8 +42,8 @@ def _parse_table(text: str) -> Tuple[List[str], List[List[str]]]:
     lines = _extract_table(text)
     if not lines:
         return [], []
-    raw_headers = [c.strip() for c in lines[0].strip("|").split("|")]
-    headers = [re.sub(r"</?abbr[^>]*>", "", h).strip() for h in raw_headers]
+    header_line = re.sub(r"<[^>]+>", "", lines[0])
+    headers = [c.strip() for c in header_line.strip("|").split("|")]
     rows = []
     for line in lines[2:]:
         cells = [c.strip() for c in line.strip("|").split("|")]

--- a/tests/test_parse_table_abbr.py
+++ b/tests/test_parse_table_abbr.py
@@ -30,3 +30,14 @@ def test_assert_equivalent_ignores_abbr():
         "| 1 | 1.0 | foo |\n"
     )
     assert_readme_equivalent(expected, actual)
+
+
+def test_parse_table_strips_generic_html():
+    table = (
+        "| <b>Rank</b> | <span>Score</span> | Repo |\n"
+        "|-----:|------:|------|\n"
+        "| 1 | 1.0 | foo |\n"
+    )
+    headers, rows = _parse_table(table)
+    assert headers == ["Rank", "Score", "Repo"]
+    assert rows == [["1", "1.0", "foo"]]


### PR DESCRIPTION
## Summary
- strip HTML tags from table header before counting columns
- test parsing when headers contain generic HTML

## Testing
- `pytest tests/test_parse_table_abbr.py -q`
- `pytest tests/test_inject_dry_run.py::test_readme_tolerances -q`
- `pytest tests/test_inject_dry_run.py::test_inject_readme_check -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d54865224832a9303e0778aadbcec