### PR TITLE
Improve README diff normalization

### DIFF
--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -32,21 +32,64 @@ def _extract_table_lines(text: str) -> list[str]:
     return [l for l in section.splitlines() if l.startswith("|")]
 
 
+def _strip_html(text: str) -> str:
+    """Return ``text`` with any HTML tags removed."""
+    return re.sub(r"<[^>]+>", "", text)
+
+
+def _normalize_header(line: str) -> list[str]:
+    cells = [c.strip() for c in line.strip().strip("|").split("|")]
+    return [re.sub(r"\s+", " ", _strip_html(c)).strip() for c in cells]
+
+
 def assert_readme_diff(old: str, new: str, *, delta: float = 0.02) -> None:
-    """Assert README tables differ only within ``delta`` for numeric cells."""
+    """Assert README tables differ only within ``delta`` for numeric cells.
+
+    Header lines are normalized by stripping HTML and collapsing whitespace so
+    minor formatting changes don't trigger failures. Numeric columns may vary
+    within ``delta``.
+    """
+
     old_lines = _extract_table_lines(old)
     new_lines = _extract_table_lines(new)
-    assert len(old_lines) == len(new_lines)
-    for i, (ol, nl) in enumerate(zip(old_lines, new_lines)):
-        if i < 2:
-            assert ol.strip() == nl.strip()
-            continue
+    assert len(old_lines) == len(new_lines), (
+        f"row count {len(old_lines)} != {len(new_lines)}"
+    )
+
+    if old_lines:
+        assert _normalize_header(old_lines[0]) == _normalize_header(new_lines[0])
+
+    ncols = len(_normalize_header(old_lines[0])) if old_lines else 0
+    for i, (ol, nl) in enumerate(zip(old_lines[2:], new_lines[2:]), start=2):
         ocells = [c.strip() for c in ol.strip().strip("|").split("|")]
         ncells = [c.strip() for c in nl.strip().strip("|").split("|")]
-        assert ocells[0] == ncells[0]
-        assert ocells[2] == ncells[2]
+        assert len(ocells) == len(ncells) == ncols, (
+            f"row {i} column count mismatch: {len(ocells)} vs {len(ncells)}"
+        )
+
+        errors: list[str] = []
+
+        if ocells[0] != ncells[0]:
+            errors.append(f"rank {ocells[0]} != {ncells[0]}")
+        if ocells[2] != ncells[2]:
+            errors.append(f"repo '{ocells[2]}' != '{ncells[2]}'")
+
         for idx in (1, 3, 4, 6, 7):
             if ocells[idx] and ncells[idx]:
-                assert abs(float(ocells[idx]) - float(ncells[idx])) <= delta
-        assert ocells[5] == ncells[5]
-        assert ocells[8] == ncells[8]
+                try:
+                    if abs(float(ocells[idx]) - float(ncells[idx])) > delta:
+                        errors.append(
+                            f"col {idx} {ocells[idx]} != {ncells[idx]}"
+                        )
+                except ValueError:
+                    if ocells[idx] != ncells[idx]:
+                        errors.append(
+                            f"col {idx} '{ocells[idx]}' != '{ncells[idx]}'"
+                        )
+
+        if ocells[5] != ncells[5]:
+            errors.append(f"release '{ocells[5]}' != '{ncells[5]}'")
+        if ocells[8] != ncells[8]:
+            errors.append(f"license '{ocells[8]}' != '{ncells[8]}'")
+
+        assert not errors, f"row {i}: " + "; ".join(errors)


### PR DESCRIPTION
## Summary
- expand `assert_readme_diff` helper
  - normalize headers by stripping HTML tags and collapsing whitespace
  - better column count checking and error reporting
  - allow numeric columns to drift within delta

## Testing
- `pytest tests/test_readme_snapshot.py::test_readme_snapshot -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d55b30954832a89f0ec477b2842e3