### PR TITLE
Handle missing snapshot in README check

### DIFF
--- a/agentic_index_cli/internal/inject_readme.py
+++ b/agentic_index_cli/internal/inject_readme.py
@@ -177,6 +177,9 @@ def main(*, force: bool = False, check: bool = False, write: bool = True, sort_b
         return 1
 
     if check:
+        if not SNAPSHOT.exists():
+            print(f"Warning: missing snapshot {SNAPSHOT}", file=sys.stderr)
+            return 0
         if diff(new_text):
             print("README.md is out of date", file=sys.stderr)
             return 1

--- a/tests/test_snapshot_presence.py
+++ b/tests/test_snapshot_presence.py
@@ -5,7 +5,7 @@ import agentic_index_cli.internal.inject_readme as inj
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_injector_handles_missing_snapshot(tmp_path, monkeypatch):
+def test_injector_handles_missing_snapshot(tmp_path, capsys, monkeypatch):
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     shutil.copy(ROOT / "data" / "top50.md", data_dir / "top50.md")
@@ -20,4 +20,7 @@ def test_injector_handles_missing_snapshot(tmp_path, monkeypatch):
     monkeypatch.setattr(inj, "REPOS_PATH", data_dir / "repos.json")
     monkeypatch.setattr(inj, "SNAPSHOT", data_dir / "last_snapshot.json")
 
-    assert inj.main(check=True) == 0
+    ret = inj.main(check=True)
+    captured = capsys.readouterr()
+    assert ret == 0
+    assert "missing snapshot" in captured.err


### PR DESCRIPTION
## Summary
- allow README injector to skip check if last_snapshot.json missing
- test missing snapshot warning

## Testing
- `pytest -q tests/test_snapshot_presence.py::test_injector_handles_missing_snapshot -vv`

------
https://chatgpt.com/codex/tasks/task_e_684d56cedcf0832a85bf21af1d75adbf