### PR TITLE
Fix Sphinx autodoc build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - name: Install docs requirements
+        run: pip install -r docs/requirements.txt
       - name: Install dependencies
         run: pip install mkdocs-material mkdocstrings[python] sphinx sphinx_rtd_theme
       - name: Build MkDocs site

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+pydantic>=2

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -8,4 +8,5 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
 html_theme = 'sphinx_rtd_theme'
 
 autodoc_typehints = 'description'
+autodoc_mock_imports = ["pydantic"]
 


### PR DESCRIPTION
## Summary
- add `docs/requirements.txt` with `pydantic`
- install docs requirements in CI
- mock pydantic when building docs

## Testing
- `pip install -r docs/requirements.txt`
- `pip install sphinx sphinx_rtd_theme`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build/html -W`
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5d497f44832a8527ed02743c811c