### PR TITLE
Automate coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,23 @@ jobs:
         run: python scripts/coverage_gate.py coverage.xml
         env:
           PYTHONHASHSEED: 0
+      - name: Coverage badge check
+        id: covbadge
+        run: python scripts/update_coverage_badge.py --check
+        continue-on-error: true
+      - name: Update coverage badge
+        if: steps.covbadge.outcome == 'failure'
+        run: python scripts/update_coverage_badge.py --write
+      - name: Auto-PR for coverage badge
+        if: steps.covbadge.outcome == 'failure'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "docs: update coverage badge"
+          branch: coverage-badge-${{ github.run_id }}
+          base: ${{ github.ref_name }}
+          title: "docs: update coverage badge"
+          body: "Automated coverage badge update"
+          delete-branch: true
       - name: Verify internal links
         run: python scripts/link_integrity.py
 

--- a/scripts/update_coverage_badge.py
+++ b/scripts/update_coverage_badge.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Update coverage badge in README from coverage.xml."""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+BADGE_RE = re.compile(r"https://img\.shields\.io/badge/coverage-\d+%25-[a-zA-Z]+")
+
+
+def fetch_badge(url: str, dest: Path) -> None:
+    """Download an SVG badge or create a local placeholder when offline."""
+    if os.getenv("CI_OFFLINE") == "1":
+        if dest.exists():
+            return
+        dest.write_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+        return
+    try:
+        import urllib.request
+
+        resp = urllib.request.urlopen(url)
+        try:
+            content = resp.read().rstrip(b"\n")
+            dest.write_bytes(content)
+        finally:
+            if hasattr(resp, "close"):
+                resp.close()
+    except Exception:
+        if dest.exists():
+            return
+        dest.write_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+
+
+def _coverage_percent(path: Path) -> int:
+    tree = ET.parse(path)
+    rate = float(tree.getroot().attrib.get("line-rate", 0)) * 100
+    return int(rate)
+
+
+def _badge_url(percent: int) -> str:
+    if percent >= 90:
+        color = "brightgreen"
+    elif percent >= 80:
+        color = "brightgreen"
+    elif percent >= 70:
+        color = "yellow"
+    elif percent >= 60:
+        color = "orange"
+    else:
+        color = "red"
+    return f"https://img.shields.io/badge/coverage-{percent}%25-{color}"
+
+
+def build_readme(readme_path: Path, percent: int) -> str:
+    text = readme_path.read_text(encoding="utf-8")
+    url = _badge_url(percent)
+    new_text = BADGE_RE.sub(url, text)
+    return new_text
+
+
+def main(readme: str = "README.md", xml: str = "coverage.xml", *, check: bool = False, write: bool = True) -> int:
+    readme_path = Path(readme)
+    xml_path = Path(xml)
+    percent = _coverage_percent(xml_path)
+    new_text = build_readme(readme_path, percent)
+    if check:
+        if new_text != readme_path.read_text(encoding="utf-8"):
+            print("Coverage badge out of date", file=sys.stderr)
+            return 1
+        return 0
+    if write and new_text != readme_path.read_text(encoding="utf-8"):
+        readme_path.write_text(new_text, encoding="utf-8")
+        fetch_badge(_badge_url(percent), Path("badges") / "coverage.svg")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Update coverage badge in README")
+    parser.add_argument("--check", action="store_true", help="Fail if badge stale")
+    parser.add_argument("--write", action="store_true", help="Write README")
+    parser.add_argument("xml", nargs="?", default="coverage.xml")
+    parser.add_argument("readme", nargs="?", default="README.md")
+    args = parser.parse_args()
+    if not args.write:
+        args.write = not args.check
+    sys.exit(main(args.readme, args.xml, check=args.check, write=args.write))

--- a/tests/test_update_coverage_badge.py
+++ b/tests/test_update_coverage_badge.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import subprocess
+import os
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / 'scripts' / 'update_coverage_badge.py'
+
+
+def _write_xml(tmp_path: Path, rate: float) -> Path:
+    p = tmp_path / 'coverage.xml'
+    p.write_text(f'<coverage line-rate="{rate}"></coverage>')
+    return p
+
+
+def test_update_badge(tmp_path):
+    readme = tmp_path / 'README.md'
+    readme.write_text('![coverage](https://img.shields.io/badge/coverage-80%25-brightgreen)')
+    xml = _write_xml(tmp_path, 0.86)
+    env = dict(os.environ)
+    env['PYTHONPATH'] = str(ROOT)
+    subprocess.run(['python', str(SCRIPT), str(xml), str(readme)], check=True, cwd=str(ROOT), env=env)
+    text = readme.read_text()
+    assert 'coverage-86%25-' in text


### PR DESCRIPTION
## Summary
- add script to update coverage badge based on coverage.xml
- add GitHub Actions step to run the script and open PRs when badge is stale
- test new script

## Testing
- `pytest tests/test_update_coverage_badge.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: requests)*

------
https://chatgpt.com/codex/tasks/task_e_684d5d40950c832aa22f54e1435cd50f