### PR TITLE
Fix docs build by adding pydantic

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Install docs requirements
+      - name: Install docs dependencies
         run: pip install -r docs/requirements.txt
       - name: Install dependencies
         run: pip install mkdocs-material mkdocstrings[python] sphinx sphinx_rtd_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
-pydantic>=2
+sphinx
+pydantic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,8 @@ dependencies = [
 [project.scripts]
 agentic-index = "agentic_index_cli.__main__:main"
 
+[project.optional-dependencies]
+docs = ["sphinx", "pydantic"]
+
 [tool.coverage.report]
 fail_under = 70  # temporary threshold, will be raised after snapshot tolerance rollout


### PR DESCRIPTION
## Summary
- ensure Sphinx can import modules by installing runtime deps via `docs/requirements.txt`
- mention docs extra deps in `pyproject.toml`
- adjust docs workflow step name

## Testing
- `pre-commit run --files .github/workflows/docs.yml docs/requirements.txt pyproject.toml`
- `pytest -q`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build/html -W`

------
https://chatgpt.com/codex/tasks/task_e_684d5eb935a0832ab360b0165772fe3e