### PR TITLE
Increase unit test coverage

### DIFF
--- a/tests/test_inject_cli_script.py
+++ b/tests/test_inject_cli_script.py
@@ -1,0 +1,19 @@
+import runpy
+import sys
+from pathlib import Path
+
+
+def test_inject_script_check(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_main(force=False, check=False, write=True, sort_by="score"):
+        calls["args"] = (force, check, write, sort_by)
+        return 0
+
+    monkeypatch.setattr(
+        "agentic_index_cli.internal.inject_readme.main", fake_main
+    )
+    script = Path(__file__).resolve().parents[1] / 'scripts' / 'inject_readme.py'
+    sys.argv = [str(script), '--check']
+    runpy.run_path(script, run_name='__main__')
+    assert calls["args"] == (False, True, False, 'score')

--- a/tests/test_plot_trends.py
+++ b/tests/test_plot_trends.py
@@ -1,0 +1,51 @@
+import importlib.util
+from pathlib import Path
+from datetime import datetime
+
+spec = importlib.util.spec_from_file_location('pt', Path('scripts/plot_trends.py'))
+pt = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pt)
+
+
+def test_load_snapshots(tmp_path):
+    hist = tmp_path
+    good = hist / '2025-01-01.json'
+    good.write_text('[{"name":"a"}]')
+    bad_name = hist / 'not-a-date.json'
+    bad_name.write_text('[]')
+    bad_json = hist / '2025-01-02.json'
+    bad_json.write_text('invalid')
+
+    dates, snaps = pt.load_snapshots(hist)
+    assert dates == [datetime(2025, 1, 1), datetime(2025, 1, 2)]
+    assert snaps[0] == [{"name": "a"}]
+    assert snaps[1] == []
+
+
+def test_build_timeseries():
+    dates = [datetime(2025, 1, 1), datetime(2025, 1, 2)]
+    snapshots = [
+        [{"name": "a", "AgentOpsScore": 1}, {"name": "b", "AgentOpsScore": 2}],
+        [{"name": "a", "AgentOpsScore": 2}, {"name": "b", "AgentOpsScore": 3}],
+    ]
+    series, repos = pt.build_timeseries(dates, snapshots)
+    assert repos == ["b", "a"]
+    assert series["a"] == [1, 2]
+    assert series["b"] == [2, 3]
+
+
+def test_plot_creates_file(tmp_path):
+    import pytest
+    pytest.importorskip("matplotlib")
+    series = {"a": [1, 2]}
+    dates = [datetime(2025, 1, 1), datetime(2025, 1, 2)]
+    out = tmp_path / 'out.png'
+    pt.plot(series, dates, out)
+    assert out.exists()
+
+
+def test_cli_placeholder(capsys):
+    from agentic_index_cli import plot_trends as cli
+    cli.main()
+    captured = capsys.readouterr()
+    assert "not yet implemented" in captured.out

--- a/tests/test_regression_check.py
+++ b/tests/test_regression_check.py
@@ -1,4 +1,5 @@
 import agentic_index_cli.internal.regression_check as rc
+from pathlib import Path
 
 
 def test_regression_allows_snapshot_mentions(tmp_path):
@@ -30,3 +31,33 @@ def test_regression_blocks_internal(tmp_path):
     config['allowlist'] = rc.load_allowlist(allow)
     failures = rc.check_files([f], config)
     assert failures
+
+def test_gather_files(monkeypatch):
+    outputs = {
+        'g1': 'a.py\nb.py\n',
+        'g2': 'b.py\nc.py\n',
+    }
+
+    def fake_check(cmd, text=True):
+        return outputs[cmd[2]]
+
+    monkeypatch.setattr(rc.subprocess, 'check_output', fake_check)
+    files = rc.gather_files(['g1', 'g2'])
+    assert files == [Path('a.py'), Path('b.py'), Path('c.py')]
+
+
+def test_main_failure(monkeypatch, tmp_path):
+    cfg = tmp_path / '.regression.yml'
+    cfg.write_text('forbidden:\n  - bad\nallowed_regex: []\n')
+    allow = tmp_path / 'regression_allowlist.yml'
+    allow.write_text('allow: []')
+    f = tmp_path / 'test.py'
+    f.write_text('bad')
+
+    monkeypatch.setattr(rc, 'gather_files', lambda globs=None: [f])
+    orig_load = rc.load_config
+    monkeypatch.setattr(rc, 'load_config', lambda path=cfg: orig_load(cfg))
+    orig_allow = rc.load_allowlist
+    monkeypatch.setattr(rc, 'load_allowlist', lambda path=allow: orig_allow(allow))
+    ret = rc.main(['--allowlist', str(allow)])
+    assert ret == 1


### PR DESCRIPTION
## Summary
- add CLI coverage test for inject_readme script
- add tests for plotting trend snapshots
- test gather_files and main error path in regression_check

## Testing
- `pytest --cov=agentic_index_cli --cov-report=xml -q`
- `python scripts/coverage_gate.py coverage.xml`


------
https://chatgpt.com/codex/tasks/task_e_684d65fd5f20832a9dd015c054cc95a0