### PR TITLE
Fix detect-large-files pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,10 +14,15 @@ repos:
         language: python
         additional_dependencies: [., pytest-cov, requests, PyYAML, jsonschema, pydantic, responses, matplotlib]
         files: \.py$
+      - id: detect-large-files
+        name: detect-large-files
+        entry: python scripts/detect_large_files.py
+        language: python
+        pass_filenames: false
+        additional_dependencies: [pre-commit-hooks==5.0.0]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
-        name: detect-large-files
         args: [--maxkb=5120]
         exclude: ^data/history/.*\.json\.gz$

--- a/scripts/detect_large_files.py
+++ b/scripts/detect_large_files.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+from pre_commit_hooks.check_added_large_files import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add wrapper script for detect-large-files
- configure new local hook that calls pre-commit-hooks
- keep check-added-large-files hook for full check
- run `pre-commit autoupdate`

## Testing
- `pre-commit run detect-large-files --files docs/secrets-and-lfs.md`
- `pre-commit run --files docs/secrets-and-lfs.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d70190518832a99468462a717835d