### PR TITLE
Fix coverage badge regex

### DIFF
--- a/scripts/update_coverage_badge.py
+++ b/scripts/update_coverage_badge.py
@@ -9,7 +9,7 @@ import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-BADGE_RE = re.compile(r"https://img\.shields\.io/badge/coverage-\d+%25-[a-zA-Z]+")
+BADGE_RE = re.compile(r"!?\[coverage\]\(https://img\.shields\.io/badge/coverage-\d+%25-[a-zA-Z]+\)")
 
 
 def fetch_badge(url: str, dest: Path) -> None:
@@ -56,9 +56,11 @@ def _badge_url(percent: int) -> str:
 
 
 def build_readme(readme_path: Path, percent: int) -> str:
+    """Return README text with an updated coverage badge."""
     text = readme_path.read_text(encoding="utf-8")
     url = _badge_url(percent)
-    new_text = BADGE_RE.sub(url, text)
+    # Normalize to image syntax in case the badge was a regular link
+    new_text = BADGE_RE.sub(f"![coverage]({url})", text)
     return new_text
 
 

--- a/tests/test_update_coverage_badge.py
+++ b/tests/test_update_coverage_badge.py
@@ -21,3 +21,15 @@ def test_update_badge(tmp_path):
     subprocess.run(['python', str(SCRIPT), str(xml), str(readme)], check=True, cwd=str(ROOT), env=env)
     text = readme.read_text()
     assert 'coverage-86%25-' in text
+
+
+def test_update_badge_add_exclamation(tmp_path):
+    readme = tmp_path / 'README.md'
+    readme.write_text('[coverage](https://img.shields.io/badge/coverage-70%25-red)')
+    xml = _write_xml(tmp_path, 0.95)
+    env = dict(os.environ)
+    env['PYTHONPATH'] = str(ROOT)
+    subprocess.run(['python', str(SCRIPT), str(xml), str(readme)], check=True, cwd=str(ROOT), env=env)
+    text = readme.read_text()
+    assert text.startswith('![coverage]')
+    assert 'coverage-95%25-' in text


### PR DESCRIPTION
## Summary
- improve regex to match entire coverage badge markdown
- normalize coverage badge to image syntax
- test updating README when exclamation mark is missing

## Testing
- `CI_OFFLINE=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d715db1f8832a9ba5bd1dd0462e0e