### PR TITLE
Add render_badge helper

### DIFF
--- a/agentic_index_cli/helpers/__init__.py
+++ b/agentic_index_cli/helpers/__init__.py
@@ -1,4 +1,6 @@
 """Helper functions for Agentic Index."""
+
+
 def add(a: int, b: int) -> int:
     """Add two integers.
 
@@ -10,3 +12,7 @@ def add(a: int, b: int) -> int:
         The sum of ``a`` and ``b``.
     """
     return a + b
+
+from .markdown import render_badge
+
+__all__ = ["add", "render_badge"]

--- a/agentic_index_cli/helpers/markdown.py
+++ b/agentic_index_cli/helpers/markdown.py
@@ -1,0 +1,32 @@
+"""Markdown rendering helpers."""
+
+
+def render_badge(label: str, url: str) -> str:
+    """Return markdown for an image badge.
+
+    Parameters
+    ----------
+    label:
+        The alt text for the badge.
+    url:
+        The badge image URL or path.
+    Returns
+    -------
+    str
+        Markdown image tag, e.g. ``![label](url)``.
+    Raises
+    ------
+    ValueError
+        If ``label`` or ``url`` is empty or contains invalid characters.
+    """
+    if not isinstance(label, str) or not isinstance(url, str):
+        raise TypeError("label and url must be strings")
+    label = label.strip()
+    url = url.strip()
+    if not label or not url:
+        raise ValueError("label and url required")
+    if any(ch in label for ch in "]()\n"):
+        raise ValueError("label contains invalid characters")
+    if any(ch in url for ch in "()\n"):
+        raise ValueError("url contains invalid characters")
+    return f"![{label}]({url})"

--- a/scripts/update_coverage_badge.py
+++ b/scripts/update_coverage_badge.py
@@ -9,6 +9,8 @@ import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+from agentic_index_cli.helpers.markdown import render_badge
+
 BADGE_RE = re.compile(r"!?\[coverage\]\(https://img\.shields\.io/badge/coverage-\d+%25-[a-zA-Z]+\)")
 
 
@@ -60,7 +62,7 @@ def build_readme(readme_path: Path, percent: int) -> str:
     text = readme_path.read_text(encoding="utf-8")
     url = _badge_url(percent)
     # Normalize to image syntax in case the badge was a regular link
-    new_text = BADGE_RE.sub(f"![coverage]({url})", text)
+    new_text = BADGE_RE.sub(render_badge("coverage", url), text)
     return new_text
 
 

--- a/tests/test_render_badge.py
+++ b/tests/test_render_badge.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import pytest
+
+# ensure project root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from agentic_index_cli.helpers.markdown import render_badge
+
+
+def test_render_badge_valid():
+    text = render_badge('build', 'badges/build.svg')
+    assert text == '![build](badges/build.svg)'
+
+
+def test_render_badge_invalid():
+    with pytest.raises(ValueError):
+        render_badge('', 'foo')
+    with pytest.raises(ValueError):
+        render_badge('build', '')
+


### PR DESCRIPTION
## Summary
- add helpers.markdown.render_badge helper
- refactor coverage badge updater to use new helper
- convert helpers to a package
- test render_badge()

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d78805e3c832a9ce2d268cf67b038