### PR TITLE
Add issue logger CLI

### DIFF
--- a/agentic_index_cli/__main__.py
+++ b/agentic_index_cli/__main__.py
@@ -50,6 +50,31 @@ def main(argv=None):
 
     prune_p.set_defaults(func=run_prune)
 
+    issue_p = subparsers.add_parser("issue-logger", help="Post GitHub issues or comments")
+    mode = issue_p.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--new-issue", action="store_true")
+    mode.add_argument("--comment", action="store_true")
+    issue_p.add_argument("--repo", required=True)
+    issue_p.add_argument("--title")
+    issue_p.add_argument("--body")
+    issue_p.add_argument("--issue-number", type=int)
+    issue_p.add_argument("--dry-run", action="store_true")
+    issue_p.add_argument("--verbose", action="store_true")
+
+    def run_issue(args):
+        from . import issue_logger
+        issue_logger.main([
+            *( ["--new-issue"] if args.new_issue else ["--comment"] ),
+            "--repo", args.repo,
+            *( ["--title", args.title] if args.title else [] ),
+            *( ["--body", args.body] if args.body else [] ),
+            *( ["--issue-number", str(args.issue_number)] if args.issue_number is not None else [] ),
+            *( ["--dry-run"] if args.dry_run else [] ),
+            *( ["--verbose"] if args.verbose else [] ),
+        ])
+
+    issue_p.set_defaults(func=run_issue)
+
     args = parser.parse_args(argv)
     args.func(args)
 

--- a/agentic_index_cli/issue_logger.py
+++ b/agentic_index_cli/issue_logger.py
@@ -1,0 +1,93 @@
+"""CLI helpers for posting GitHub issues or comments."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Any, Dict
+
+import requests
+
+from .exceptions import APIError
+
+API_URL = "https://api.github.com"
+
+
+def _headers(token: str | None) -> Dict[str, str]:
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+    return headers
+
+
+def get_token() -> str | None:
+    """Return GitHub token from environment if available."""
+    return os.getenv("GITHUB_TOKEN") or os.getenv("GITHUB_TOKEN_ISSUES")
+
+
+def create_issue(repo: str, title: str, body: str, *, token: str | None = None) -> Dict[str, Any]:
+    """Create a new issue on ``repo`` and return the JSON response."""
+    token = token or get_token()
+    resp = requests.post(
+        f"{API_URL}/repos/{repo}/issues",
+        json={"title": title, "body": body},
+        headers=_headers(token),
+        timeout=10,
+    )
+    if resp.status_code >= 400:
+        raise APIError(f"{resp.status_code} {resp.text}")
+    return resp.json()
+
+
+def post_comment(repo: str, issue_number: int, body: str, *, token: str | None = None) -> Dict[str, Any]:
+    """Post a comment to an existing issue and return the JSON response."""
+    token = token or get_token()
+    resp = requests.post(
+        f"{API_URL}/repos/{repo}/issues/{issue_number}/comments",
+        json={"body": body},
+        headers=_headers(token),
+        timeout=10,
+    )
+    if resp.status_code >= 400:
+        raise APIError(f"{resp.status_code} {resp.text}")
+    return resp.json()
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for issue/comment logging."""
+    parser = argparse.ArgumentParser(description="Post GitHub issues or comments")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--new-issue", action="store_true", help="create a new issue")
+    mode.add_argument("--comment", action="store_true", help="comment on an issue")
+    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument("--title")
+    parser.add_argument("--body", default="")
+    parser.add_argument("--issue-number", type=int)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.new_issue:
+        if not args.title:
+            parser.error("--title required for --new-issue")
+        if args.dry_run:
+            if args.verbose:
+                print(f"DRY RUN: would create issue in {args.repo}")
+            return
+        data = create_issue(args.repo, args.title, args.body)
+        if args.verbose:
+            print(data.get("html_url", ""))
+    else:
+        if args.issue_number is None:
+            parser.error("--issue-number required for --comment")
+        if args.dry_run:
+            if args.verbose:
+                print(f"DRY RUN: would comment on issue {args.issue_number} in {args.repo}")
+            return
+        data = post_comment(args.repo, args.issue_number, args.body)
+        if args.verbose:
+            print(data.get("html_url", ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/agents.md
+++ b/agents.md
@@ -15,6 +15,7 @@ Agentic Index curates & ranks AI-agent repos so developers can quickly find reli
 | TrendGrapher | update.yml | `agentic_index_cli/plot_trends.py` | Plot score trends | `docs/trends/*.png` |
 | SiteDeployer | gh-pages | `.github/workflows/deploy_site.yml` | Publish /web to Pages | live site URL |
 | SafeRebase | comment /rebase | `.github/actions/safe-rebase/action.yml` | Rebase PR into new branch | draft <orig>-rebased PR |
+| IssueLogger | manual / CI | `agentic_index_cli/issue_logger.py` | Post GitHub issues/comments | Issue/Comment URLs |
 
 Add any new agents as you implement them.*
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -56,3 +56,17 @@ Whenever `data/top100.md` or `data/repos.json` change, regenerate the README and
 commit the updated files so `tests/test_inject_dry_run.py` stays in sync. The
 test tolerates minor score drift (±0.01) but still fails if the table structure
 diverges.
+
+### IssueLogger
+
+Use the `issue-logger` command to post a GitHub issue or comment from scripts or
+CI pipelines.
+
+```bash
+python -m agentic_index_cli.issue_logger \
+  --repo owner/repo --new-issue \
+  --title "CI Failure" --body "See logs for details"
+```
+
+The tool reads a token from `GITHUB_TOKEN` or falls back to
+`GITHUB_TOKEN_ISSUES`.

--- a/tests/test_issue_logger.py
+++ b/tests/test_issue_logger.py
@@ -1,0 +1,35 @@
+import os
+import responses
+import pytest
+
+import agentic_index_cli.issue_logger as il
+
+
+def test_token_fallback(monkeypatch):
+    monkeypatch.delenv('GITHUB_TOKEN', raising=False)
+    monkeypatch.setenv('GITHUB_TOKEN_ISSUES', 'tok')
+    assert il.get_token() == 'tok'
+
+
+def test_cli_create_issue(monkeypatch):
+    called = {}
+
+    def fake_create(repo, title, body):
+        called['args'] = (repo, title, body)
+        return {'html_url': 'x'}
+
+    monkeypatch.setattr(il, 'create_issue', fake_create)
+    il.main(['--new-issue', '--repo', 'o/r', '--title', 't', '--body', 'b'])
+    assert called['args'] == ('o/r', 't', 'b')
+
+
+@responses.activate
+def test_post_comment_error(monkeypatch):
+    responses.add(
+        responses.POST,
+        'https://api.github.com/repos/o/r/issues/1/comments',
+        json={'message': 'bad'},
+        status=401,
+    )
+    with pytest.raises(il.APIError):
+        il.post_comment('o/r', 1, 'msg', token='bad')


### PR DESCRIPTION
## Summary
- implement IssueLogger for posting GitHub issues/comments
- wire up new `issue-logger` subcommand
- document IssueLogger agent and usage
- add basic tests

## Testing
- `pre-commit run --files agentic_index_cli/issue_logger.py agentic_index_cli/__main__.py agents.md docs/DEVELOPMENT.md tests/test_issue_logger.py` *(fails: Required test coverage of 70.0% not reached)*
- `pytest tests/test_issue_logger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8049a04c832aa0edfca9c1e81ab8