### PR TITLE
Add /score API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,30 +31,22 @@ Small fluctuations up to ±0.02 are normal between refreshes. See the [📊 Metr
 -----
 
 <p align="center">
-  <a href="https://github.com/adrianwedd/Agentic-Index/actions/workflows/ci.yml">
-    <img src="badges/build.svg" alt="Build Status" />
-  </a>
-  <a href="https://github.com/adrianwedd/Agentic-Index/actions/workflows/ci.yml">
-    <img src="https://img.shields.io/badge/coverage-80%25-brightgreen" alt="Coverage" />
-  </a>
-  <a href="https://pypi.org/project/agentic-index/">
-    <img src="badges/pypi.svg" alt="PyPI" />
-  </a>
-  <a href="./LICENSE">
-    <img src="badges/license.svg" alt="License" />
-  </a>
+![build](badges/build.svg)
+![coverage](https://img.shields.io/badge/coverage-80%25-brightgreen)
+![PyPI](badges/pypi.svg)
+![license](badges/license.svg)
 </p>
 <details>
 <summary>More status badges</summary>
 
 <p align="center">
-  <img src="badges/docs.svg" alt="Documentation" />
-  <img src="https://img.shields.io/website?down_message=offline&up_message=online&url=https%3A%2F%2Fadrianwedd.github.io%2FAgentic-Index" alt="Site Status" />
-  <img src="https://img.shields.io/github/release/adrianwedd/Agentic-Index?include_prereleases" alt="Release Notes" />
-  <img src="badges/coc.svg" alt="Code of Conduct" />
-  <img src="badges/last_sync.svg" alt="Last Sync" />
-  <img src="badges/top_repo.svg" alt="Top Repo" />
-  <img src="badges/repo_count.svg" alt="Repo Count" />
+![docs](badges/docs.svg)
+![Site](https://img.shields.io/website?down_message=offline&up_message=online&url=https%3A%2F%2Fadrianwedd.github.io%2FAgentic-Index)
+![Release Notes](https://img.shields.io/github/release/adrianwedd/Agentic-Index?include_prereleases)
+![Code of Conduct](badges/coc.svg)
+![Last Sync](badges/last_sync.svg)
+![Top Repo](badges/top_repo.svg)
+![Repo Count](badges/repo_count.svg)
 </p>
 </details>
 
@@ -399,5 +391,3 @@ The content of Agentic-Index (this `README.md`, files in `/docs/`, etc.) is lice
 Any scripts or code for analysis and generation (e.g., in `/scripts`, if we add 'em) are licensed under([https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)).
 
 © 2025 Agentic-Index Maintainers
-
-

--- a/agents.md
+++ b/agents.md
@@ -16,6 +16,7 @@ Agentic Index curates & ranks AI-agent repos so developers can quickly find reli
 | SiteDeployer | gh-pages | `.github/workflows/deploy_site.yml` | Publish /web to Pages | live site URL |
 | SafeRebase | comment /rebase | `.github/actions/safe-rebase/action.yml` | Rebase PR into new branch | draft <orig>-rebased PR |
 | IssueLogger | manual / CI | `agentic_index_cli/issue_logger.py` | Post GitHub issues/comments | Issue/Comment URLs |
+| GhAPIServer | manual | `gh_api.py` | Serve API endpoints | `state/*.json` |
 
 Add any new agents as you implement them.*
 

--- a/gh_api.py
+++ b/gh_api.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from fastapi import FastAPI
+
+from agentic_index_cli.validate import load_repos, save_repos
+from agentic_index_cli.internal.rank import (
+    compute_score,
+    infer_category,
+    SCORE_KEY,
+)
+
+
+def get_state_dir() -> Path:
+    return Path(os.getenv("STATE_DIR", "state"))
+
+
+def load_sync_data() -> list[dict]:
+    path = get_state_dir() / "sync_data.json"
+    return load_repos(path) if path.exists() else []
+
+
+def save_scored_data(repos: list[dict]) -> None:
+    path = get_state_dir() / "scored_data.json"
+    save_repos(path, repos)
+
+
+app = FastAPI()
+
+
+@app.post("/score")
+def score_endpoint():
+    repos = load_sync_data()
+    for repo in repos:
+        repo[SCORE_KEY] = compute_score(repo)
+        repo["category"] = infer_category(repo)
+    repos.sort(key=lambda r: r[SCORE_KEY], reverse=True)
+    save_scored_data(repos)
+    top_scores = [r[SCORE_KEY] for r in repos[:5]]
+    return {"top_scores": top_scores}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8000")))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "PyYAML",
     "jsonschema>=3.2",
     "pydantic>=2",
+    "fastapi>=0.110",
+    "httpx",
 ]
 
 [project.scripts]

--- a/requirements.lock
+++ b/requirements.lock
@@ -13,10 +13,11 @@ contourpy==1.3.2
 coverage==7.9.1
 cycler==0.12.1
 docutils==0.21.2
-fastapi==0.97.0
+fastapi==0.115.12
 fonttools==4.58.4
 h11==0.16.0
 hypothesis==6.135.9
+httpx==0.28.1
 idna==3.10
 imagesize==1.4.1
 iniconfig==2.1.0
@@ -66,7 +67,7 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
-starlette==0.27.0
+starlette==0.46.2
 stdlib-list==0.11.1
 typing-inspection==0.4.1
 typing_extensions==4.13.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ responses
 jsonschema>=3.2
 pydantic>=2
 matplotlib
+fastapi>=0.110
+httpx
 
 pydeps
 sphinx

--- a/tests/test_gh_api_score.py
+++ b/tests/test_gh_api_score.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+import gh_api
+from agentic_index_cli.validate import load_repos
+from agentic_index_cli.internal.rank import SCORE_KEY
+
+
+def test_score_endpoint(tmp_path, monkeypatch):
+    state = tmp_path / "state"
+    state.mkdir()
+    sync_path = state / "sync_data.json"
+    data = {
+        "schema_version": 1,
+        "repos": [
+            {
+                "name": "r1",
+                "stargazers_count": 10,
+                "open_issues_count": 1,
+                "closed_issues": 2,
+                "pushed_at": "2025-06-01T00:00:00Z",
+                "license": {"spdx_id": "MIT"},
+            },
+            {
+                "name": "r2",
+                "stargazers_count": 5,
+                "open_issues_count": 0,
+                "closed_issues": 0,
+                "pushed_at": "2025-05-20T00:00:00Z",
+                "license": {"spdx_id": "MIT"},
+            },
+        ],
+    }
+    sync_path.write_text(json.dumps(data))
+    monkeypatch.setenv("STATE_DIR", str(state))
+    client = TestClient(gh_api.app)
+    resp = client.post("/score")
+    assert resp.status_code == 200
+    scores = resp.json()["top_scores"]
+    assert scores and all(s > 0 for s in scores)
+    scored = load_repos(state / "scored_data.json")
+    expected = [r[SCORE_KEY] for r in sorted(scored, key=lambda r: r[SCORE_KEY], reverse=True)[:5]]
+    assert scores == expected


### PR DESCRIPTION
## Summary
- implement `gh_api.py` with POST /score
- store API state files under new `state/` dir
- document new API agent in `agents.md`
- add test covering /score endpoint
- standardize README badge formatting
- include fastapi/httpx dependencies
- remove unused import in test

## Testing
- `pytest -q tests/test_gh_api_score.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d824a87c4832ab545744bc701a01f