### PR TITLE
Implement scoring data loader

### DIFF
--- a/tests/test_api_score.py
+++ b/tests/test_api_score.py
@@ -1,11 +1,39 @@
+import json
 from fastapi.testclient import TestClient
-from agentic_index_api.server import app
+import importlib
+import agentic_index_api.server as srv
+from tests.test_api_auth import load_app
 
 
-def test_score_endpoint():
-    client = TestClient(app)
-    resp = client.post("/score", json={})
+def make_client(monkeypatch, tmp_path, data=None):
+    if data is not None:
+        path = tmp_path / "sync.json"
+        path.write_text(json.dumps(data))
+    else:
+        path = tmp_path / "missing.json"
+    app, mod = load_app(monkeypatch, key="k")
+    monkeypatch.setattr(mod, "SYNC_DATA_PATH", path)
+    return TestClient(app), {"X-API-KEY": "k"}
+
+
+def test_score_endpoint_loads_data(tmp_path, monkeypatch):
+    client, headers = make_client(monkeypatch, tmp_path, [{"name": "repo1"}, {"full_name": "a/b"}])
+    resp = client.post("/score", json={}, headers=headers)
     assert resp.status_code == 200
-    data = resp.json()
-    assert "top_scores" in data
-    assert isinstance(data["top_scores"], list)
+    assert resp.json()["top_scores"] == ["repo1", "a/b"]
+
+
+def test_score_missing_file(tmp_path, monkeypatch):
+    client, headers = make_client(monkeypatch, tmp_path)
+    resp = client.post("/score", json={}, headers=headers)
+    assert resp.status_code == 400
+
+
+def test_score_invalid_file(tmp_path, monkeypatch):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{}")
+    app, mod = load_app(monkeypatch, key="k")
+    monkeypatch.setattr(mod, "SYNC_DATA_PATH", bad)
+    client = TestClient(app)
+    resp = client.post("/score", json={}, headers={"X-API-KEY": "k"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- load sync data JSON for `/score`
- validate loaded data
- test scoring endpoint with valid, missing, and invalid files

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest tests/test_api_score.py::test_score_endpoint_loads_data -q`


------
https://chatgpt.com/codex/tasks/task_e_684e3a9a510c832a9ab5f38d91dd5c96