### PR TITLE
Implement score endpoint

### DIFF
--- a/agentic_index_cli/__main__.py
+++ b/agentic_index_cli/__main__.py
@@ -2,7 +2,6 @@ import logging
 
 """Entrypoint for the ``agentic-index`` command line tool."""
 
-import argparse
 from pathlib import Path
 from typing import List, Optional
 
@@ -10,11 +9,6 @@ import requests
 import typer
 
 from . import agentic_index, enricher, faststart, prune
-
-def main(argv=None):
-    """Dispatch subcommands for the CLI."""
-    parser = argparse.ArgumentParser(prog="agentic-index", description="Agentic Index CLI")
-    subparsers = parser.add_subparsers(dest="command", required=True)
 
 app = typer.Typer(add_completion=True, help="Agentic Index CLI")
 
@@ -82,33 +76,7 @@ def run(args: Optional[List[str]] = None) -> None:
         typer.secho(f"Unknown error: {exc}", fg="red", err=True)
         raise SystemExit(3)
 
-    issue_p = subparsers.add_parser("issue-logger", help="Post GitHub issues or comments")
-    mode = issue_p.add_mutually_exclusive_group(required=True)
-    mode.add_argument("--new-issue", action="store_true")
-    mode.add_argument("--comment", action="store_true")
-    issue_p.add_argument("--repo", required=True)
-    issue_p.add_argument("--title")
-    issue_p.add_argument("--body")
-    issue_p.add_argument("--issue-number", type=int)
-    issue_p.add_argument("--dry-run", action="store_true")
-    issue_p.add_argument("--verbose", action="store_true")
-
-    def run_issue(args):
-        from . import issue_logger
-        issue_logger.main([
-            *( ["--new-issue"] if args.new_issue else ["--comment"] ),
-            "--repo", args.repo,
-            *( ["--title", args.title] if args.title else [] ),
-            *( ["--body", args.body] if args.body else [] ),
-            *( ["--issue-number", str(args.issue_number)] if args.issue_number is not None else [] ),
-            *( ["--dry-run"] if args.dry_run else [] ),
-            *( ["--verbose"] if args.verbose else [] ),
-        ])
-
-    issue_p.set_defaults(func=run_issue)
-
-    args = parser.parse_args(argv)
-    args.func(args)
+    return
 
 
 def main(args: Optional[List[str]] = None) -> None:

--- a/agentic_index_cli/agentic_index.py
+++ b/agentic_index_cli/agentic_index.py
@@ -336,8 +336,8 @@ def run_index(min_stars: int = 0, iterations: int = 1, output: Path = Path("data
         final_repos = top
 
     if not is_test or output != Path("data"):
-        save_csv(final_repos, output / "top50.csv")
-        save_markdown(final_repos, output / "top50.md")
+        save_csv(final_repos, output / "top100.csv")
+        save_markdown(final_repos, output / "top100.md")
         changes = changelog(prev_repos, [r["name"] for r in final_repos])
         save_changelog(changes, output / "CHANGELOG.md")
 

--- a/repos.json
+++ b/repos.json
@@ -1,1 +1,1 @@
-[{"name": "repo1", "AgentOpsScore": 10}, {"name": "repo2", "AgentOpsScore": 9}, {"name": "repo3", "AgentOpsScore": 8}, {"name": "repo4", "AgentOpsScore": 7}, {"name": "repo5", "AgentOpsScore": 6}]
+{"repos": [{"name": "repo1", "AgentOpsScore": 10}, {"name": "repo2", "AgentOpsScore": 9}, {"name": "repo3", "AgentOpsScore": 8}, {"name": "repo4", "AgentOpsScore": 7}, {"name": "repo5", "AgentOpsScore": 6}]}

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -25,11 +25,13 @@ def test_protected_requires_auth(monkeypatch):
         assert resp.status_code == 401
 
 
-def test_api_key_header(monkeypatch):
+def test_api_key_header(monkeypatch, tmp_path):
     app, mod = load_app(monkeypatch, key="sekret")
     monkeypatch.setattr(mod, "scrape", lambda *a, **k: [])
     monkeypatch.setattr(mod, "save_repos", lambda *a, **k: None)
-    monkeypatch.setattr(mod, "rank_main", lambda *a, **k: None)
+    sync = tmp_path / "sync.json"
+    sync.write_text("[]")
+    monkeypatch.setattr(mod, "SYNC_DATA_PATH", sync)
     import sys, types
     dummy = types.SimpleNamespace(main=lambda *a, **k: None)
     monkeypatch.setitem(sys.modules, "agentic_index_cli.generate_outputs", dummy)


### PR DESCRIPTION
## Summary
- sort by score for `/score` API
- streamline CLI entrypoint
- output top100 files in ranking helper
- patch fixtures for main API tests
- adjust score endpoint tests

## Testing
- `python -m pytest tests/test_api_score.py tests/test_api_auth.py tests/test_cli.py tests/test_main_cli.py tests/test_run_index.py -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3cff1910832aac951ba9927434fe