### PR TITLE
Add initial Codex queue scaffolding

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -1,0 +1,11 @@
+queue:
+  - GH-API-03a
+  - GH-API-03b
+  - GH-API-03c
+mode: sequential
+on_block:
+  - explain: true
+  - request_human_input: true
+report:
+  - status: after_each
+  - format: markdown

--- a/.codex/ticket_template.md
+++ b/.codex/ticket_template.md
@@ -1,0 +1,10 @@
+### <TICKET_ID> \u2022 <TITLE>
+
+**Goal:** <Summary>
+
+**Tasks:**
+- [ ] Step 1
+- [ ] Step 2
+
+**Acceptance Criteria:**
+- Expected output, validation steps.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,18 @@ python scripts/inject_readme.py
 Touch files under `score/*.py`, update `scripts/inject_readme.py` and document your column in `README.md`. Include tests covering the metric and regenerate snapshots with the injector.
 New metrics should maintain overall test coverage (see badges) and update any affected snapshots.
 
+## Codex Queue
+
+Automation tasks can be orchestrated through a simple queue file located at `.codex/queue.yml`.
+To simulate execution locally run:
+
+```bash
+python scripts/codex_task_runner.py
+```
+
+Define modular tasks in the YAML file to integrate with Codex tooling.
+
+
 
 
 

--- a/scripts/codex_task_runner.py
+++ b/scripts/codex_task_runner.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Simple Codex queue runner."""
+
+from pathlib import Path
+import yaml
+
+
+def load_queue(path: Path = Path('.codex/queue.yml')) -> dict:
+    """Return queue definition from YAML file."""
+    with path.open('r', encoding='utf-8') as fh:
+        return yaml.safe_load(fh)
+
+
+def run_queue(queue: dict) -> None:
+    """Print each task ID in sequence."""
+    tasks = queue.get('queue', [])
+    for idx, task in enumerate(tasks, 1):
+        print(f"[Task {idx}] {task}")
+        # In a real implementation this would hand off to Codex CLI
+
+
+def main() -> None:
+    queue = load_queue()
+    run_queue(queue)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `.codex/queue.yml` to define queued tasks
- provide `.codex/ticket_template.md` for ticket drafts
- introduce `scripts/codex_task_runner.py` to load and print the queue
- document the Codex queue in `CONTRIBUTING.md`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e5800ed58832a960ec65f03c13290