### PR TITLE
Implement codex_task_runner scaffolding

### DIFF
--- a/scripts/codex_task_runner.py
+++ b/scripts/codex_task_runner.py
@@ -1,28 +1,141 @@
 #!/usr/bin/env python3
-"""Simple Codex queue runner."""
+"""Parse and process tasks defined in ``codex_tasks.md``.
 
+This script extracts code blocks fenced with ``codex-task`` from a markdown file,
+parses the YAML metadata for each task and prints them in a structured format.
+
+The intended task schema is roughly::
+
+    ```codex-task
+    id: TASK-001
+    title: Example task
+    priority: 1
+    steps:
+      - do one thing
+    acceptance_criteria:
+      - results logged
+    ```
+
+Tasks are sorted by ``priority`` and ``id``. Use ``--start-from`` to begin from a
+specific task ID and ``--summary-only`` to only list IDs and titles.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
 from pathlib import Path
+from typing import Any, Dict, List
+
 import yaml
 
-
-def load_queue(path: Path = Path('.codex/queue.yml')) -> dict:
-    """Return queue definition from YAML file."""
-    with path.open('r', encoding='utf-8') as fh:
-        return yaml.safe_load(fh)
+# Regex to extract fenced code blocks labelled "codex-task"
+CODE_BLOCK_RE = re.compile(r"```codex-task\n(?P<code>.*?)\n```", re.DOTALL)
 
 
-def run_queue(queue: dict) -> None:
-    """Print each task ID in sequence."""
-    tasks = queue.get('queue', [])
-    for idx, task in enumerate(tasks, 1):
-        print(f"[Task {idx}] {task}")
-        # In a real implementation this would hand off to Codex CLI
+def parse_tasks(path: Path) -> List[Dict[str, Any]]:
+    """Return a list of task dictionaries parsed from ``path``."""
+    text = path.read_text(encoding="utf-8")
+    tasks: List[Dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for block in CODE_BLOCK_RE.findall(text):
+        try:
+            data = yaml.safe_load(block) or {}
+        except yaml.YAMLError as exc:  # malformed YAML
+            logging.warning("YAML error while parsing task block: %s", exc)
+            continue
+
+        if not isinstance(data, dict):
+            logging.warning("Skipping task block, expected mapping but got %r", data)
+            continue
+
+        task_id = data.get("id")
+        if not task_id:
+            logging.warning("Skipping task block with missing 'id'")
+            continue
+        if task_id in seen_ids:
+            logging.warning("Duplicate task id %s skipped", task_id)
+            continue
+
+        try:
+            data["priority"] = int(data.get("priority", 0))
+        except (ValueError, TypeError):
+            logging.warning("Invalid priority for task %s; defaulting to 0", task_id)
+            data["priority"] = 0
+
+        tasks.append(data)
+        seen_ids.add(task_id)
+
+    return tasks
 
 
-def main() -> None:
-    queue = load_queue()
-    run_queue(queue)
+def sort_tasks(tasks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return tasks sorted by ``priority`` then ``id``."""
+    return sorted(tasks, key=lambda t: (t.get("priority", 0), t.get("id", "")))
 
 
-if __name__ == '__main__':
-    main()
+def format_task(task: Dict[str, Any]) -> str:
+    lines = [f"ID: {task.get('id')}", f"Title: {task.get('title', '')}"]
+    steps = task.get("steps") or []
+    if steps:
+        lines.append("Steps:")
+        lines.extend(f" - {s}" for s in steps)
+    ac = task.get("acceptance_criteria") or []
+    if ac:
+        lines.append("Acceptance Criteria:")
+        lines.extend(f" - {c}" for c in ac)
+    return "\n".join(lines)
+
+
+def write_summary(summary: str) -> None:
+    """If running in GitHub Actions, append ``summary`` to the step summary."""
+    summary_file = os.getenv("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as fh:
+            fh.write(summary + "\n")
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Process Codex tasks")
+    parser.add_argument("--file", default="codex_tasks.md", help="Tasks markdown file")
+    parser.add_argument("--start-from", metavar="ID", help="Start processing from this task ID")
+    parser.add_argument("--summary-only", action="store_true", help="Only output IDs and titles")
+    args = parser.parse_args(argv)
+
+    path = Path(args.file)
+    if not path.exists():
+        print(f"Error: tasks file not found: {path}", file=sys.stderr)
+        return 1
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    tasks = sort_tasks(parse_tasks(path))
+    if args.start_from:
+        try:
+            start_index = next(i for i, t in enumerate(tasks) if t.get("id") == args.start_from)
+            tasks = tasks[start_index:]
+        except StopIteration:
+            logging.warning("start-from id %s not found", args.start_from)
+            tasks = []
+
+    output_lines = []
+    if args.summary_only:
+        for t in tasks:
+            output_lines.append(f"{t.get('id')}: {t.get('title', '')}")
+    else:
+        for t in tasks:
+            output_lines.append(format_task(t))
+            output_lines.append("")
+
+    output = "\n".join(output_lines).rstrip()
+    if output:
+        print(output)
+        write_summary(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_codex_task_runner.py
+++ b/tests/test_codex_task_runner.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+# ensure project root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import scripts.codex_task_runner as ctr
+
+SAMPLE_MD = """
+# Tasks
+
+```codex-task
+id: TASK-2
+priority: 2
+title: Second task
+steps:
+  - step two
+acceptance_criteria:
+  - done
+```
+
+```codex-task
+id: TASK-1
+priority: 1
+title: First task
+```
+"""
+
+def test_parse_and_sort(tmp_path, capsys):
+    md = tmp_path / "codex_tasks.md"
+    md.write_text(SAMPLE_MD)
+
+    tasks = ctr.sort_tasks(ctr.parse_tasks(md))
+    assert [t["id"] for t in tasks] == ["TASK-1", "TASK-2"]
+
+    ctr.main(["--file", str(md), "--summary-only"])
+    out = capsys.readouterr().out
+    assert "TASK-1" in out
+    assert "First task" in out
+    assert "TASK-2" in out
+
+    ctr.main(["--file", str(md), "--summary-only", "--start-from", "TASK-2"])
+    out = capsys.readouterr().out
+    assert "TASK-1" not in out
+    assert "TASK-2" in out


### PR DESCRIPTION
## Summary
- rewrite `scripts/codex_task_runner.py` to parse tasks from `codex_tasks.md`
- add CLI flags for filtering and summary output
- append GitHub Actions summary when available
- test task parsing and CLI behaviour

## Testing
- `pytest tests/test_codex_task_runner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684e5b11c590832a88d861722f29b4ed