### PR TITLE
Enable issue logging via Codex Runner

### DIFF
--- a/agentic_index_api/server.py
+++ b/agentic_index_api/server.py
@@ -123,13 +123,10 @@ async def issue(payload: IssueBody) -> Any:
 
     def _run() -> Any:
         if payload.issue_number is not None:
-            return issue_logger.post_comment(
-                payload.repo, payload.issue_number, payload.body, token=token
-            )
+            issue_url = f"https://api.github.com/repos/{payload.repo}/issues/{payload.issue_number}"
+            return issue_logger.post_comment(issue_url, payload.body, token=token)
         if not payload.title:
             raise HTTPException(status_code=400, detail="title required")
-        return issue_logger.create_issue(
-            payload.repo, payload.title, payload.body, token=token
-        )
+        return issue_logger.create_issue(payload.title, payload.body, payload.repo, token=token)
 
     return await run_in_threadpool(_run)

--- a/agentic_index_cli/api_server.py
+++ b/agentic_index_cli/api_server.py
@@ -37,11 +37,12 @@ def issue_endpoint(payload: IssueRequest):
         if payload.type == "issue":
             if not payload.title:
                 raise HTTPException(status_code=400, detail="title required for new issue")
-            data = create_issue(payload.repo, payload.title, payload.body, token=token)
+            url = create_issue(payload.title, payload.body, payload.repo, token=token)
         else:
             if payload.issue_number is None:
                 raise HTTPException(status_code=400, detail="issue_number required for comment")
-            data = post_comment(payload.repo, payload.issue_number, payload.body, token=token)
+            issue_url = f"https://api.github.com/repos/{payload.repo}/issues/{payload.issue_number}"
+            url = post_comment(issue_url, payload.body, token=token)
     except APIError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
-    return {"url": data.get("html_url", "")}
+    return {"url": url}

--- a/tests/test_api_issue.py
+++ b/tests/test_api_issue.py
@@ -11,9 +11,9 @@ def test_token_priority(monkeypatch):
 def test_issue_comment(monkeypatch):
     called = {}
 
-    def fake_comment(repo, issue_number, body, *, token=None):
-        called['args'] = (repo, issue_number, body, token)
-        return {'html_url': 'u'}
+    def fake_comment(issue_url, body, *, token=None):
+        called['args'] = (issue_url, body, token)
+        return 'u'
 
     monkeypatch.setattr(api, 'post_comment', fake_comment)
     client = TestClient(api.app)
@@ -28,7 +28,7 @@ def test_issue_comment(monkeypatch):
     )
     assert resp.status_code == 200
     assert resp.json() == {"url": "u"}
-    assert called['args'] == ('o/r', 1, 'msg', None)
+    assert called['args'] == ('https://api.github.com/repos/o/r/issues/1', 'msg', None)
 
 
 def test_issue_missing_field(monkeypatch):

--- a/tests/test_codex_issue_logger.py
+++ b/tests/test_codex_issue_logger.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import scripts.codex_task_runner as ctr
+import agentic_index_cli.issue_logger as il
+
+SAMPLE = """
+```codex-task
+id: TEST-1
+title: Sample
+create_issue: true
+repo: o/r
+body: body text
+labels: [auto, codex]
+```
+"""
+
+
+def test_runner_creates_issue(monkeypatch, tmp_path):
+    md = tmp_path / "tasks.md"
+    md.write_text(SAMPLE)
+
+    called = {}
+
+    def fake_create(title, body, repo, labels=None, *, token=None):
+        called["args"] = (title, body, repo, labels)
+        return "url"
+
+    monkeypatch.setattr(il, "create_issue", fake_create)
+    ctr.main(["--file", str(md)])
+
+    assert called["args"] == (
+        "Sample",
+        "body text\n\nTask ID: TEST-1",
+        "o/r",
+        ["auto", "codex"],
+    )
+

--- a/tests/test_issue_logger.py
+++ b/tests/test_issue_logger.py
@@ -14,13 +14,13 @@ def test_token_fallback(monkeypatch):
 def test_cli_create_issue(monkeypatch):
     called = {}
 
-    def fake_create(repo, title, body):
-        called['args'] = (repo, title, body)
-        return {'html_url': 'x'}
+    def fake_create(title, body, repo):
+        called['args'] = (title, body, repo)
+        return 'x'
 
     monkeypatch.setattr(il, 'create_issue', fake_create)
     il.main(['--new-issue', '--repo', 'o/r', '--title', 't', '--body', 'b'])
-    assert called['args'] == ('o/r', 't', 'b')
+    assert called['args'] == ('t', 'b', 'o/r')
 
 
 @responses.activate
@@ -32,4 +32,4 @@ def test_post_comment_error(monkeypatch):
         status=401,
     )
     with pytest.raises(il.APIError):
-        il.post_comment('o/r', 1, 'msg', token='bad')
+        il.post_comment('https://api.github.com/repos/o/r/issues/1', 'msg', token='bad')


### PR DESCRIPTION
## Summary
- refactor `issue_logger` API to return HTML URLs and handle missing tokens
- update CLI and API server for new signatures
- integrate issue creation in `codex_task_runner`
- expose simple plugin registry for agent actions
- add tests for new behaviours

## Testing
- `pytest tests/test_codex_issue_logger.py tests/test_issue_logger.py tests/test_api_issue.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684e67a5c8d0832a86c87574bc58bb4c