### PR TITLE
Fix Sphinx build missing dependency

### DIFF
--- a/agentic_index_cli/enricher.py
+++ b/agentic_index_cli/enricher.py
@@ -4,8 +4,7 @@ import argparse
 import math
 from pathlib import Path
 
-from .agentic_index import (compute_issue_health, compute_recency_factor,
-                            license_freedom)
+from .agentic_index import compute_issue_health, compute_recency_factor, license_freedom
 from .validate import load_repos, save_repos
 
 

--- a/agentic_index_cli/internal/rank.py
+++ b/agentic_index_cli/internal/rank.py
@@ -14,9 +14,11 @@ import sys
 import urllib.request
 from pathlib import Path
 
-from agentic_index_cli.agentic_index import (compute_issue_health,
-                                             compute_recency_factor,
-                                             license_freedom)
+from agentic_index_cli.agentic_index import (
+    compute_issue_health,
+    compute_recency_factor,
+    license_freedom,
+)
 from agentic_index_cli.config import load_config
 from agentic_index_cli.validate import load_repos, save_repos
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 pydantic
+rich


### PR DESCRIPTION
## Summary
- add the `rich` package to docs requirements
- run isort/black to fix import formatting

## Testing
- `black --check . && isort --profile black --check-only .`
- `PYTHONPATH="$PWD" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e8002ced4832a8f271bd2c8b1dadf