### PR TITLE
Remove deprecated score field references

### DIFF
--- a/agentic_index_cli/internal/inject_readme.py
+++ b/agentic_index_cli/internal/inject_readme.py
@@ -17,6 +17,7 @@ RANKED_PATH = ROOT / "data" / "ranked.json"
 SNAPSHOT = ROOT / "data" / "last_snapshot.json"
 
 OVERALL_COL = "Overall"
+DEFAULT_SORT_FIELD = "overall"
 
 START = "<!-- TOP50:START -->"
 END = "<!-- TOP50:END -->"
@@ -30,7 +31,7 @@ def _clamp_name(name: str, limit: int = 28) -> str:
     return safe[: limit - 3] + "..."
 
 
-def _load_rows(sort_by: str = "score", *, limit: int = 100) -> list[str]:
+def _load_rows(sort_by: str = DEFAULT_SORT_FIELD, *, limit: int = 100) -> list[str]:
     """Return table rows computed from repo data using v2 fields.
 
     If ``data/ranked.json`` is present it is used in preference to
@@ -73,7 +74,7 @@ def _load_rows(sort_by: str = "score", *, limit: int = 100) -> list[str]:
         parsed.append(
             {
                 "name": name,
-                "score": repo_score,
+                "overall": repo_score,
                 "stars_7d": stars7,
                 "maintenance": maint_fmt,
                 "maintenance_sort": maint_val,
@@ -98,7 +99,7 @@ def _load_rows(sort_by: str = "score", *, limit: int = 100) -> list[str]:
         rows.append(
             "| {i} | {score:.2f} | {name} | {s30} | {maint} | {rel} | {docs} | {eco} | {lic} |".format(
                 i=i,
-                score=repo["score"],
+                score=repo["overall"],
                 name=_clamp_name(repo["name"]),
                 s30=repo["stars_7d"],
                 maint=repo["maintenance"],
@@ -133,7 +134,7 @@ def _fmt_delta(val: str | int | float, *, is_int: bool = False) -> str:
         return val
 
 
-def build_readme(*, sort_by: str = "score", limit: int | None = None) -> str:
+def build_readme(*, sort_by: str = DEFAULT_SORT_FIELD, limit: int | None = None) -> str:
     """Return README text with the top100 table injected."""
     readme_text = README_PATH.read_text(encoding="utf-8")
     end_newline = readme_text.endswith("\n")
@@ -188,7 +189,7 @@ def main(
     force: bool = False,
     check: bool = False,
     write: bool = True,
-    sort_by: str = "score",
+    sort_by: str = DEFAULT_SORT_FIELD,
 ) -> int:
     """Synchronise the README table.
 
@@ -201,7 +202,7 @@ def main(
     write:
         Whether to update ``README.md``. Defaults to ``True``.
     sort_by:
-        Field to sort by. One of ``score``, ``stars_7d``, ``maintenance``, or ``last_release``.
+        Field to sort by. One of ``overall``, ``stars_7d``, ``maintenance``, or ``last_release``.
     """
     try:
         new_text = build_readme(sort_by=sort_by)

--- a/agentic_index_cli/internal/rank.py
+++ b/agentic_index_cli/internal/rank.py
@@ -161,8 +161,6 @@ def main(json_path: str = "data/repos.json", *, config: dict | None = None) -> N
     for repo in repos:
         if "AgentOpsScore" in repo:
             repo[SCORE_KEY] = repo.pop("AgentOpsScore")
-        if "score" in repo and SCORE_KEY not in repo:
-            repo[SCORE_KEY] = repo.pop("score")
 
     # ensure essential fields exist; fall back to raw GitHub data when missing
     for repo in repos:

--- a/agentic_index_cli/validate.py
+++ b/agentic_index_cli/validate.py
@@ -73,8 +73,6 @@ def _migrate_item(item: dict) -> dict:
     item = dict(item)
     if "AgentOpsScore" in item:
         item["AgenticIndexScore"] = item.pop("AgentOpsScore")
-    if "score" in item and "AgenticIndexScore" not in item:
-        item["AgenticIndexScore"] = item.pop("score")
     if isinstance(item.get("license"), dict):
         item["license"] = item["license"].get("spdx_id")
     return item

--- a/scripts/inject_readme.py
+++ b/scripts/inject_readme.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from agentic_index_cli.internal.inject_readme import main
+from agentic_index_cli.internal.inject_readme import DEFAULT_SORT_FIELD, main
 
 if __name__ == "__main__":
     import argparse
@@ -27,8 +27,8 @@ if __name__ == "__main__":
     parser.add_argument("--force", action="store_true", help="Write even if unchanged")
     parser.add_argument(
         "--sort-by",
-        default="score",
-        choices=["score", "stars_7d", "maintenance", "last_release"],
+        default=DEFAULT_SORT_FIELD,
+        choices=["overall", "stars_7d", "maintenance", "last_release"],
         help="Sort table by metric",
     )
     args = parser.parse_args()

--- a/tests/test_inject_cli_script.py
+++ b/tests/test_inject_cli_script.py
@@ -6,7 +6,7 @@ from pathlib import Path
 def test_inject_script_check(monkeypatch, tmp_path):
     calls = {}
 
-    def fake_main(force=False, check=False, write=True, sort_by="score"):
+    def fake_main(force=False, check=False, write=True, sort_by="overall"):
         calls["args"] = (force, check, write, sort_by)
         return 0
 
@@ -14,4 +14,4 @@ def test_inject_script_check(monkeypatch, tmp_path):
     script = Path(__file__).resolve().parents[1] / "scripts" / "inject_readme.py"
     sys.argv = [str(script), "--check"]
     runpy.run_path(script, run_name="__main__")
-    assert calls["args"] == (False, True, False, "score")
+    assert calls["args"] == (False, True, False, "overall")

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -54,7 +54,7 @@ def _setup(tmp_path: Path):
 @pytest.mark.parametrize(
     "field,first",
     [
-        ("score", "B"),
+        ("overall", "B"),
         ("stars_7d", "A"),
         ("maintenance", "B"),
         ("last_release", "A"),


### PR DESCRIPTION
## Summary
- drop legacy `score` keyword in injector and ranking
- update validation to omit `score` migration
- switch README injector default sort field to `overall`
- update CLI script and tests for new sort field

## Testing
- `black --check . && isort --check-only --profile black .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7fba6078832a981a84bf4fdd2570