### PR TITLE
Add issue-url option to issue_logger

### DIFF
--- a/agentic_index_cli/issue_logger.py
+++ b/agentic_index_cli/issue_logger.py
@@ -254,10 +254,11 @@ def main(argv: list[str] | None = None) -> None:
     mode.add_argument("--comment", action="store_true", help="comment on an issue")
     mode.add_argument("--update", action="store_true", help="update issue fields")
     mode.add_argument("--close", action="store_true", help="close an issue")
-    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument("--repo", help="owner/repo")
     parser.add_argument("--title")
     parser.add_argument("--body", default="")
     parser.add_argument("--issue-number", type=int)
+    parser.add_argument("--issue-url")
     parser.add_argument("--assign", action="append", default=[])
     parser.add_argument("--milestone", type=int)
     parser.add_argument("--dry-run", action="store_true")
@@ -277,10 +278,20 @@ def main(argv: list[str] | None = None) -> None:
             print(url)
         return
 
-    if args.issue_number is None:
-        parser.error("--issue-number required")
+    if not args.issue_number and not args.issue_url:
+        parser.error("--issue-number or --issue-url required")
 
-    issue_url = f"https://api.github.com/repos/{args.repo}/issues/{args.issue_number}"
+    if args.issue_url:
+        repo, num = _parse_issue_or_pr_url(args.issue_url)
+        issue_url = f"https://api.github.com/repos/{repo}/issues/{num}"
+        if not args.repo:
+            args.repo = repo
+    else:
+        if not args.repo:
+            parser.error("--repo required")
+        issue_url = (
+            f"https://api.github.com/repos/{args.repo}/issues/{args.issue_number}"
+        )
 
     if args.dry_run:
         if args.verbose:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -88,5 +88,13 @@ python -m agentic_index_cli.issue_logger --update \
   --repo owner/repo --issue-number 5 --body "Updated text"
 ```
 
+You can also target an existing issue directly with a full URL:
+
+```bash
+python -m agentic_index_cli.issue_logger --comment \
+  --issue-url https://github.com/owner/repo/issues/5 \
+  --body "Looks good!"
+```
+
 Pass `--debug` to print API calls or `--dry-run` to simulate without creating
 anything.


### PR DESCRIPTION
## Summary
- allow `--issue-url` so repo and number can be inferred from a full URL
- document the new `--issue-url` option in `DEVELOPMENT.md`

## Testing
- `python -m agentic_index_cli.issue_logger --new-issue --repo octocat/Hello-World --title test --body body --dry-run --verbose`
- `python -m agentic_index_cli.issue_logger --comment --repo octocat/Hello-World --issue-number 1 --body hi --dry-run --verbose`
- `PYTHONPATH="$PWD" pytest -q`
- `black --check .`
- `isort --check-only .` *(fails: enricher.py, internal/rank.py)*

------
https://chatgpt.com/codex/tasks/task_e_684e84a3f690832a96b8c2f31d71d810