### PR TITLE
Fix tests imports and add isort config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         name: pytest
         entry: pytest --quiet --cov=agentic_index_cli --cov-fail-under=0
         language: python
-        additional_dependencies: [., pytest-cov, requests, PyYAML, jsonschema, pydantic, responses, matplotlib, fastapi, httpx]
+        additional_dependencies: [., pytest-cov, requests, PyYAML, jsonschema, pydantic, responses, matplotlib, fastapi, httpx, rich]
         files: \.py$
       - id: detect-large-files
         name: detect-large-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "PyYAML",
     "jsonschema>=3.2",
     "pydantic>=2",
+    "rich",
 ]
 
 [project.scripts]
@@ -23,3 +24,6 @@ dev = ["fastapi", "httpx"]
 
 [tool.coverage.report]
 fail_under = 70  # temporary threshold, will be raised after snapshot tolerance rollout
+
+[tool.isort]
+profile = "black"

--- a/tests/test_api_score.py
+++ b/tests/test_api_score.py
@@ -3,7 +3,8 @@ import json
 from fastapi.testclient import TestClient
 
 from agentic_index_cli.internal.rank import compute_score
-from tests.test_api_auth import load_app
+
+from .test_api_auth import load_app
 
 
 def make_client(monkeypatch, tmp_path, data=None):

--- a/tests/test_inject_dry_run.py
+++ b/tests/test_inject_dry_run.py
@@ -8,9 +8,9 @@ import pytest
 # ensure project root is on the path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from helpers import assert_readme_equivalent
-
 import agentic_index_cli.internal.inject_readme as inj
+
+from .helpers import assert_readme_equivalent
 
 FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
 README_SNAP = FIXTURE_DIR / "README_fixture.md"

--- a/tests/test_parse_table_abbr.py
+++ b/tests/test_parse_table_abbr.py
@@ -4,7 +4,7 @@ from pathlib import Path
 # ensure project root is on the path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from helpers import _parse_table, assert_readme_equivalent
+from .helpers import _parse_table, assert_readme_equivalent
 
 
 def test_parse_table_strips_abbr():

--- a/tests/test_readme_snapshot.py
+++ b/tests/test_readme_snapshot.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
 
-from _utils import assert_readme_diff
+from ._utils import assert_readme_diff
 
 ROOT = Path(__file__).resolve().parents[1]
 SNAP = ROOT / "tests" / "snapshots" / "README.md"


### PR DESCRIPTION
## Summary
- make tests package importable
- update pytest hook dependencies
- include `rich` in project dependencies
- configure isort to match black

## Testing
- `PYTHONPATH="$PWD" pytest -q`
- `black --check . && isort --check-only .`


------
https://chatgpt.com/codex/tasks/task_e_684e88b0a4e4832a824b3de405114c89