### PR TITLE
Fix Codex issue logger test for CI

### DIFF
--- a/tests/test_codex_issue_logger.py
+++ b/tests/test_codex_issue_logger.py
@@ -19,6 +19,9 @@ labels: [auto, codex]
 
 
 def test_runner_creates_issue(monkeypatch, tmp_path):
+    monkeypatch.delenv("GITHUB_SERVER_URL", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
     md = tmp_path / "tasks.md"
     md.write_text(SAMPLE)
 


### PR DESCRIPTION
## Summary
- avoid GitHub environment variables in `test_runner_creates_issue`

## Testing
- `PYTHONPATH="$PWD" pytest -q`
- `pytest --cov=agentic_index_cli --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_684e8cb43e78832a9192c4e4c95560cb