### PR TITLE
Add labels and debug options to issue logger

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -78,7 +78,7 @@ Create an issue and assign a user:
 ```bash
 python -m agentic_index_cli.issue_logger \
   --repo owner/repo --new-issue --title "Bug" \
-  --body "Details" --assign your-user
+  --body "Details" --assign your-user --label bug --milestone 1
 ```
 
 Update the body of issue #5:

--- a/tests/test_codex_issue_logger.py
+++ b/tests/test_codex_issue_logger.py
@@ -27,8 +27,10 @@ def test_runner_creates_issue(monkeypatch, tmp_path):
 
     called = {}
 
-    def fake_create(title, body, repo, labels=None, *, token=None):
-        called["args"] = (title, body, repo, labels)
+    def fake_create(
+        title, body, repo, labels=None, milestone=None, *, token=None, debug=False
+    ):
+        called["args"] = (title, body, repo, labels, milestone, debug)
         return "url"
 
     monkeypatch.setattr(il, "create_issue", fake_create)
@@ -39,4 +41,6 @@ def test_runner_creates_issue(monkeypatch, tmp_path):
         "body text\n\nTask ID: TEST-1",
         "o/r",
         ["auto", "codex"],
+        None,
+        False,
     )

--- a/tests/test_issue_logger.py
+++ b/tests/test_issue_logger.py
@@ -15,13 +15,30 @@ def test_token_fallback(monkeypatch):
 def test_cli_create_issue(monkeypatch):
     called = {}
 
-    def fake_create(title, body, repo):
-        called["args"] = (title, body, repo)
+    def fake_create(
+        title, body, repo, labels=None, milestone=None, *, token=None, debug=False
+    ):
+        called["args"] = (title, body, repo, labels, milestone, debug)
         return "x"
 
     monkeypatch.setattr(il, "create_issue", fake_create)
-    il.main(["--new-issue", "--repo", "o/r", "--title", "t", "--body", "b"])
-    assert called["args"] == ("t", "b", "o/r")
+    il.main(
+        [
+            "--new-issue",
+            "--repo",
+            "o/r",
+            "--title",
+            "t",
+            "--body",
+            "b",
+            "--label",
+            "l1",
+            "--milestone",
+            "3",
+            "--debug",
+        ]
+    )
+    assert called["args"] == ("t", "b", "o/r", ["l1"], 3, True)
 
 
 @responses.activate


### PR DESCRIPTION
## Summary
- extend `issue_logger` to pass labels and milestones when creating issues
- allow debug logging for issue creation and comments
- expose `--label` flag in CLI documentation and CLI parser
- adjust tests for updated CLI helpers

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9e62c990832a9d82d078f9caa295