### PR TITLE
Improve test coverage

### DIFF
--- a/tests/test_inject_readme_cli.py
+++ b/tests/test_inject_readme_cli.py
@@ -1,0 +1,12 @@
+import agentic_index_cli.inject_readme as ir
+
+
+def test_cli_forwards_force(monkeypatch):
+    called = {}
+
+    def fake_main(force=False):
+        called["force"] = force
+
+    monkeypatch.setattr(ir, "main", fake_main)
+    ir.cli(["--force"])
+    assert called["force"] is True


### PR DESCRIPTION
## Summary
- add CLI test for inject_readme
- extend task daemon tests for skip logic and worklog posting

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest --cov=agentic_index_cli --cov-report=xml -q`
- `python scripts/coverage_gate.py coverage.xml`


------
https://chatgpt.com/codex/tasks/task_e_684e9f7cc5fc832aa5721e22b31401bb