### PR TITLE
Fix pytest-socket for TestClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ pytest -q
 
 CI runs tests with network access disabled. Set `CI_OFFLINE=1` or run
 `pytest --disable-socket` locally to replicate the offline environment.
+An autouse fixture still permits UNIX-domain `socketpair()` calls so FastAPI's
+`TestClient` can start its event loop.
 
 To check accessibility after building the site:
 

--- a/tests/fixtures/README_fixture.md
+++ b/tests/fixtures/README_fixture.md
@@ -317,6 +317,8 @@ pytest -q
 
 CI runs tests with network access disabled. Set `CI_OFFLINE=1` or run
 `pytest --disable-socket` locally to replicate the offline environment.
+An autouse fixture still permits UNIX-domain `socketpair()` calls so FastAPI's
+`TestClient` can start its event loop.
 
 To check accessibility after building the site:
 

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -332,6 +332,8 @@ pytest -q
 
 CI runs tests with network access disabled. Set `CI_OFFLINE=1` or run
 `pytest --disable-socket` locally to replicate the offline environment.
+An autouse fixture still permits UNIX-domain `socketpair()` calls so FastAPI's
+`TestClient` can start its event loop.
 
 To check accessibility after building the site:
 


### PR DESCRIPTION
## Summary
- allow AF_UNIX sockets during tests so FastAPI TestClient works
- document fixture in README and update test fixtures

## Testing
- `PYTHONPATH="$PWD" pytest -q`
- `black --check .`
- `isort --check-only .`


------
https://chatgpt.com/codex/tasks/task_e_684eb9a09fe4832abb6fb3f4e685ff12