### PR TITLE
Fix CI setup for black and isort

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ Set up Python 3.11 and install dependencies:
 ```bash
 pip install -r requirements.txt
 pip install -e .
+pip install black isort  # formatting tools
 pip install pre-commit
 pre-commit install
 ```

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Check out [CONTRIBUTING.md](./CONTRIBUTING.md) for how to:
   * Install [Git LFS](https://git-lfs.github.com/) and run `git lfs install`.
     PNG and GIF assets are tracked via LFS.
   * Set up your dev environment with [DEVELOPMENT.md](./docs/DEVELOPMENT.md).
-  * Install dependencies with `scripts/agent-setup.sh`.
+  * Install dependencies with `scripts/agent-setup.sh` (includes formatting tools).
 
 For tips on keeping your branch in sync with `main` and resolving conflicts, see
 [CONFLICT_RESOLUTION.md](./docs/CONFLICT_RESOLUTION.md).

--- a/scripts/agent-setup.sh
+++ b/scripts/agent-setup.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 # Install project dependencies
 pip install -r requirements.txt
 pip install -e .
+# Install tooling used in CI
+pip install black isort
 # Install pre-commit hooks for linting
 pip install pre-commit
 pre-commit install --install-hooks

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -355,7 +355,7 @@ Check out [CONTRIBUTING.md](./CONTRIBUTING.md) for how to:
   * Install [Git LFS](https://git-lfs.github.com/) and run `git lfs install`.
     PNG and GIF assets are tracked via LFS.
   * Set up your dev environment with [DEVELOPMENT.md](./docs/DEVELOPMENT.md).
-  * Install dependencies with `scripts/agent-setup.sh`.
+  * Install dependencies with `scripts/agent-setup.sh` (includes formatting tools).
 
 For tips on keeping your branch in sync with `main` and resolving conflicts, see
 [CONFLICT_RESOLUTION.md](./docs/CONFLICT_RESOLUTION.md).


### PR DESCRIPTION
## Summary
- install `black` and `isort` via `scripts/agent-setup.sh`
- document installing formatting tools in CONTRIBUTING
- clarify README instructions
- update README snapshot

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fac5352e0832a97e48f784d204623