### PR TITLE
Fix mkdocs gh-pages push

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -28,6 +28,7 @@ jobs:
           publish_dir: web/dist
           publish_branch: gh-pages
           github_token: ${{ github.token }}
+          force_orphan: true
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'


### PR DESCRIPTION
## Summary
- avoid gh-pages push conflicts by forcing orphan commits

## Testing
- `bash scripts/agent-setup.sh`
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe33ed014832aa752fb44972f8a59