### PR TITLE
Fix preview comment workflow

### DIFF
--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -48,7 +48,7 @@ jobs:
           publish_dir: public
           force_orphan: true
       - name: Comment PR with preview URL
-        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request')
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests)
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
## Summary
- handle missing pull request info when posting preview URL

## Testing
- `PYTHONPATH="$PWD" pytest -q`
- `black --check .`
- `isort --check-only .`

------
https://chatgpt.com/codex/tasks/task_e_684fe37ad08c832aa1fb989248b2832e