### PR TITLE
Update Repo model for new enrichment fields

### DIFF
--- a/agentic_index_cli/validate.py
+++ b/agentic_index_cli/validate.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 from typing import List
 
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 
 class License(BaseModel):
@@ -53,11 +53,13 @@ class Repo(BaseModel):
     one_liner: str | None = None
     stars_7d: int | None = None
     maintenance: float | None = None
-    docs_score: float | None = None
-    ecosystem: float | None = None
+    docs_score: float | None = Field(None, alias="docs_quality")
+    ecosystem: float | None = Field(None, alias="ecosystem_fit")
+    release_age: int | None = None
+    license_score: float | None = None
     last_release: str | None = None
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
 
 class RepoFile(BaseModel):
@@ -66,7 +68,7 @@ class RepoFile(BaseModel):
     schema_version: int = 2
     repos: List[Repo]
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
 
 def _migrate_item(item: dict) -> dict:

--- a/tests/test_validation_extra.py
+++ b/tests/test_validation_extra.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+
+
+def test_validation_extra(tmp_path):
+    repo = {
+        "full_name": "owner/repo",
+        "stargazers_count": 5,
+        "forks_count": 1,
+        "open_issues_count": 0,
+        "pushed_at": "2025-01-01T00:00:00Z",
+        "license": {"spdx_id": "MIT"},
+        "owner": {"login": "owner"},
+        "stars_7d": 1,
+        "maintenance": 0.5,
+        "docs_quality": 0.5,
+        "ecosystem_fit": 0.3,
+        "release_age": 10,
+        "license_score": 9.5,
+    }
+    path = tmp_path / "repos.json"
+    path.write_text(json.dumps({"schema_version": 2, "repos": [repo]}))
+    result = subprocess.run(
+        ["python", "-m", "agentic_index_cli.validate", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- allow `docs_quality` / `ecosystem_fit` aliases
- accept new fields `license_score` and `release_age`
- test validation with new enrichment fields

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe4c5264c832a9c32799902731d78