### PR TITLE
Improve GitHub scraper retries

### DIFF
--- a/tests/test_scrape_repos.py
+++ b/tests/test_scrape_repos.py
@@ -41,7 +41,7 @@ def test_one_shot_fields(tmp_path, monkeypatch):
     }
     release = {"published_at": "2025-05-01T00:00:00Z"}
 
-    def fake_get(url, headers=None):
+    def fake_get(url, headers=None, timeout=None):
         if url.endswith("/repos/owner/repo"):
             return make_response(repo)
         if url.endswith("/repos/owner/repo/releases/latest"):


### PR DESCRIPTION
## Summary
- add `retry` decorator for HTTP calls with exponential backoff
- apply timeout and rate-limit handling to `_get`
- fetch latest release using `_get`
- log scraper progress and failures
- adjust tests for timeout argument

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fea27a290832ab808001a6d897cf1