### PR TITLE
Expand coverage for metrics and scoring

### DIFF
--- a/tests/test_agentic_index_network.py
+++ b/tests/test_agentic_index_network.py
@@ -1,0 +1,124 @@
+import base64
+import types
+
+import agentic_index_cli.agentic_index as ai
+
+
+class DummyResp:
+    def __init__(self, data, status=200):
+        self._data = data
+        self.status_code = status
+        self.text = ""
+
+    def json(self):
+        return self._data
+
+
+def test_github_search(monkeypatch):
+    captured = {}
+
+    def fake_get(url, params=None, headers=None):
+        captured["params"] = params
+        return DummyResp({"items": ["ok"]})
+
+    monkeypatch.setattr(ai, "time", types.SimpleNamespace(sleep=lambda x: None))
+    monkeypatch.setattr(ai.requests, "get", fake_get)
+    res = ai.github_search("query", page=3)
+    assert res == ["ok"]
+    assert captured["params"]["page"] == 3
+
+
+def test_fetch_repo_and_readme(monkeypatch):
+    def fake_get_repo(url, headers=None):
+        return DummyResp({"id": 123})
+
+    encoded = base64.b64encode(b"hello").decode()
+
+    def fake_get_readme(url, headers=None):
+        return DummyResp({"content": encoded})
+
+    monkeypatch.setattr(ai, "time", types.SimpleNamespace(sleep=lambda x: None))
+    monkeypatch.setattr(ai.requests, "get", fake_get_repo)
+    repo = ai.fetch_repo("owner/name")
+    assert repo == {"id": 123}
+
+    monkeypatch.setattr(ai.requests, "get", fake_get_readme)
+    text = ai.fetch_readme("owner/name")
+    assert text == "hello"
+
+
+def test_harvest_repo(monkeypatch):
+    meta = {
+        "description": "d",
+        "stargazers_count": 1,
+        "forks_count": 1,
+        "open_issues_count": 0,
+        "closed_issues": 1,
+        "pushed_at": "2025-01-01T00:00:00Z",
+        "language": "Python",
+        "license": {"spdx_id": "MIT"},
+        "owner": {"login": "me"},
+        "topics": ["tool"],
+    }
+    monkeypatch.setattr(ai, "fetch_repo", lambda name: meta)
+    monkeypatch.setattr(ai, "fetch_readme", lambda name: "README")
+    monkeypatch.setattr(ai, "compute_score", lambda r, rd: 1.0)
+    monkeypatch.setattr(ai, "categorize", lambda desc, t: "General")
+    res = ai.harvest_repo("owner/name")
+    assert res["name"] == "owner/name"
+    assert ai.SCORE_KEY in res
+
+
+def test_error_branches(monkeypatch):
+    monkeypatch.setattr(ai, "time", types.SimpleNamespace(sleep=lambda x: None))
+
+    def bad_get(url, params=None, headers=None):
+        return DummyResp({}, status=500)
+
+    monkeypatch.setattr(ai.requests, "get", bad_get)
+    assert ai.github_search("q") == []
+
+    assert ai.fetch_repo("name") is None
+
+    assert ai.fetch_readme("name") == ""
+
+    def ok_get(url, params=None, headers=None):
+        return DummyResp({}, status=200)
+
+    monkeypatch.setattr(ai.requests, "get", ok_get)
+    assert ai.fetch_readme("name") == ""
+
+
+def test_harvest_repo_none(monkeypatch):
+    monkeypatch.setattr(ai, "fetch_repo", lambda name: None)
+    assert ai.harvest_repo("name") is None
+
+
+def test_search_topics_duplicate(monkeypatch):
+    monkeypatch.setattr(ai, "time", types.SimpleNamespace(sleep=lambda x: None))
+    calls = []
+
+    def fake_search(query, page):
+        calls.append(page)
+        return [{"full_name": "dupe"}]
+
+    monkeypatch.setattr(ai, "SEARCH_TERMS", [])
+    monkeypatch.setattr(ai, "TOPIC_FILTERS", ["topic"])
+    monkeypatch.setattr(ai, "github_search", fake_search)
+    monkeypatch.setattr(ai, "harvest_repo", lambda name: {"name": name})
+
+    repos = ai.search_and_harvest(max_pages=2)
+    assert len(repos) == 1
+    assert calls == [1, 2]
+
+
+def test_changelog_and_save(tmp_path):
+    changes = ai.changelog(["a", "b"], ["b", "c"])
+    path = tmp_path / "changelog.md"
+    ai.save_changelog(changes, path)
+    assert path.exists()
+
+    empty = ai.changelog(["a"], ["a"])
+    path2 = tmp_path / "none.md"
+    ai.save_changelog(empty, path2)
+    assert not path2.exists()

--- a/tests/test_quality_metrics_extra.py
+++ b/tests/test_quality_metrics_extra.py
@@ -1,0 +1,79 @@
+import math
+from datetime import datetime, timedelta
+
+import agentic_index_cli.agentic_index as ai
+from lib.quality_metrics import _clamp
+
+
+def test_clamp_bounds():
+    assert _clamp(-1) == 0.0
+    assert _clamp(2) == 1.0
+    assert _clamp(0.5) == 0.5
+
+
+def test_compute_recency_factor_boundaries(monkeypatch):
+    fixed_now = datetime(2025, 1, 1)
+
+    class DummyDatetime(datetime):
+        @classmethod
+        def utcnow(cls):
+            return fixed_now
+
+    monkeypatch.setattr(ai, "datetime", DummyDatetime)
+
+    recent = (fixed_now - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    mid = (fixed_now - timedelta(days=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    old = (fixed_now - timedelta(days=400)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    assert ai.compute_recency_factor(recent) == 1.0
+    expected_mid = max(0.0, 1 - (200 - 30) / 335)
+    assert math.isclose(ai.compute_recency_factor(mid), expected_mid)
+    assert ai.compute_recency_factor(old) == 0.0
+
+
+def test_compute_issue_health_zero_denominator():
+    assert ai.compute_issue_health(0, 0) == 1.0
+    almost = ai.compute_issue_health(1, 0)
+    assert almost < 0.001
+
+
+def test_license_freedom_variants():
+    assert ai.license_freedom("MIT") == 1.0
+    assert ai.license_freedom("GPL-3.0") == 0.5
+    assert ai.license_freedom("Unknown") == 0.5
+    assert ai.license_freedom(None) == 0.0
+
+
+def test_ecosystem_integration_keywords():
+    readme = "This tool integrates with LangChain"
+    assert ai.ecosystem_integration(["misc"], readme) == 1.0
+    assert ai.ecosystem_integration([], "nothing here") == 0.0
+
+
+def test_compute_score_composition(monkeypatch):
+    repo = {
+        "stargazers_count": 10,
+        "open_issues_count": 1,
+        "closed_issues": 9,
+        "pushed_at": "2025-01-01T00:00:00Z",
+        "license": {"spdx_id": "MIT"},
+        "topics": [],
+    }
+
+    monkeypatch.setattr(ai, "compute_recency_factor", lambda x: 0.5)
+    monkeypatch.setattr(ai, "compute_issue_health", lambda a, b: 0.8)
+    monkeypatch.setattr(ai, "readme_doc_completeness", lambda r: 0.6)
+    monkeypatch.setattr(ai, "license_freedom", lambda l: 1.0)
+    monkeypatch.setattr(ai, "ecosystem_integration", lambda t, r: 0.0)
+
+    score = ai.compute_score(repo, "readme")
+    expected = (
+        0.30 * math.log2(10 + 1)
+        + 0.25 * 0.5
+        + 0.20 * 0.8
+        + 0.15 * 0.6
+        + 0.07 * 1.0
+        + 0.03 * 0.0
+    )
+    expected = round(expected * 100 / 8, 2)
+    assert math.isclose(score, expected)


### PR DESCRIPTION
## Summary
- add tests for clamping, recency factor boundaries and compute_score composition
- cover network and error paths in agentic_index helper utilities

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`
- `coverage run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fec8f8300832a9fe641ba3056736c