### PR TITLE
Add security and style gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,30 @@ jobs:
           fi
       - name: Setup environment
         run: bash scripts/agent-setup.sh
-      - name: Lint
-        run: black --check . && isort --check-only .
+      - name: Lint and type check
+        run: |
+          black --check .
+          isort --check-only .
+          flake8 .
+          mypy agentic_index_cli
+          bandit -r agentic_index_cli -f json -o bandit.json
+      - name: Security badge check
+        id: secbadge
+        run: python scripts/update_security_badge.py --check bandit.json
+        continue-on-error: true
+      - name: Update security badge
+        if: steps.secbadge.outcome == 'failure'
+        run: python scripts/update_security_badge.py --write bandit.json
+      - name: Auto-PR for security badge
+        if: steps.secbadge.outcome == 'failure'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "docs: update security badge"
+          branch: security-badge-${{ github.run_id }}
+          base: ${{ github.event.repository.default_branch }}
+          title: "docs: update security badge"
+          body: "Automated security badge update"
+          delete-branch: true
       - name: Run tests
         env:
           PYTHONPATH: ${{ github.workspace }}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Small fluctuations up to ±0.02 are normal between refreshes. See the [📊 Metr
 <p align="center">
 ![build](badges/build.svg)
 ![coverage](https://img.shields.io/badge/coverage-80%25-brightgreen)
+![security](https://img.shields.io/badge/security-0%20issues-brightgreen)
 ![docs](badges/docs.svg)
 ![Site](https://img.shields.io/website?down_message=offline&up_message=online&url=https%3A%2F%2Fadrianwedd.github.io%2FAgentic-Index)
 ![license](badges/license.svg)

--- a/badges/security.svg
+++ b/badges/security.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"></svg>

--- a/scripts/agent-setup.sh
+++ b/scripts/agent-setup.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 pip install -r requirements.txt
 pip install -e .
 # Install tooling used in CI
-pip install black isort
+pip install black isort flake8 mypy bandit
 # Install pre-commit hooks for linting
 pip install pre-commit
 pre-commit install --install-hooks

--- a/scripts/update_security_badge.py
+++ b/scripts/update_security_badge.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Update security badge in README from bandit.json."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from agentic_index_cli.helpers.markdown import render_badge
+
+BADGE_RE = re.compile(
+    r"!?\[security\]\(https://img\.shields\.io/badge/security-\d+%20issues-[a-zA-Z]+\)"
+)
+
+
+def fetch_badge(url: str, dest: Path) -> None:
+    """Download an SVG badge or create a local placeholder when offline."""
+    if os.getenv("CI_OFFLINE") == "1":
+        if dest.exists():
+            return
+        dest.write_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+        return
+    try:
+        import urllib.request
+
+        resp = urllib.request.urlopen(url)
+        try:
+            content = resp.read().rstrip(b"\n")
+            dest.write_bytes(content)
+        finally:
+            if hasattr(resp, "close"):
+                resp.close()
+    except Exception:
+        if dest.exists():
+            return
+        dest.write_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+
+
+def _issue_count(path: Path) -> int:
+    data = json.loads(path.read_text())
+    return len(data.get("results", []))
+
+
+def _badge_url(count: int) -> str:
+    if count == 0:
+        color = "brightgreen"
+    elif count <= 5:
+        color = "yellow"
+    else:
+        color = "red"
+    return f"https://img.shields.io/badge/security-{count}%20issues-{color}"
+
+
+def build_readme(readme_path: Path, count: int) -> str:
+    text = readme_path.read_text(encoding="utf-8")
+    url = _badge_url(count)
+    new_text = BADGE_RE.sub(render_badge("security", url), text)
+    return new_text
+
+
+def main(
+    readme: str = "README.md",
+    report: str = "bandit.json",
+    *,
+    check: bool = False,
+    write: bool = True,
+) -> int:
+    readme_path = Path(readme)
+    report_path = Path(report)
+    count = _issue_count(report_path)
+    new_text = build_readme(readme_path, count)
+    if check:
+        if new_text != readme_path.read_text(encoding="utf-8"):
+            print("Security badge out of date", file=sys.stderr)
+            return 1
+        return 0
+    if write and new_text != readme_path.read_text(encoding="utf-8"):
+        readme_path.write_text(new_text, encoding="utf-8")
+        fetch_badge(_badge_url(count), Path("badges") / "security.svg")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Update security badge in README")
+    parser.add_argument("--check", action="store_true", help="Fail if badge stale")
+    parser.add_argument("--write", action="store_true", help="Write README")
+    parser.add_argument("report", nargs="?", default="bandit.json")
+    parser.add_argument("readme", nargs="?", default="README.md")
+    args = parser.parse_args()
+    if not args.write:
+        args.write = not args.check
+    sys.exit(main(args.readme, args.report, check=args.check, write=args.write))

--- a/tests/test_update_security_badge.py
+++ b/tests/test_update_security_badge.py
@@ -1,0 +1,51 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "update_security_badge.py"
+
+
+def _write_json(tmp_path: Path, issues: int) -> Path:
+    data = {"results": ["x"] * issues}
+    p = tmp_path / "bandit.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+def test_update_badge(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "![security](https://img.shields.io/badge/security-0%20issues-brightgreen)"
+    )
+    report = _write_json(tmp_path, 3)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(ROOT)
+    subprocess.run(
+        ["python", str(SCRIPT), str(report), str(readme)],
+        check=True,
+        cwd=str(ROOT),
+        env=env,
+    )
+    text = readme.read_text()
+    assert "security-3%20issues-" in text
+
+
+def test_update_badge_add_exclamation(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "[security](https://img.shields.io/badge/security-5%20issues-red)"
+    )
+    report = _write_json(tmp_path, 1)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(ROOT)
+    subprocess.run(
+        ["python", str(SCRIPT), str(report), str(readme)],
+        check=True,
+        cwd=str(ROOT),
+        env=env,
+    )
+    text = readme.read_text()
+    assert text.startswith("![security]")
+    assert "security-1%20issues-" in text


### PR DESCRIPTION
## Summary
- add security badge placeholder
- install bandit, flake8 and mypy during setup
- track bandit issues with an update script and tests
- run bandit, flake8, mypy and update badge in CI

## Testing
- `bash scripts/agent-setup.sh`
- `PYTHONPATH="$PWD" pytest -q`
- `black --check . && isort --check-only .`


------
https://chatgpt.com/codex/tasks/task_e_684ff44dd914832a864df050e250df91