### PR TITLE
Implement PR issue sync

### DIFF
--- a/.github/workflows/pr-sync.yml
+++ b/.github/workflows/pr-sync.yml
@@ -1,0 +1,20 @@
+name: PR-Issue Sync
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, closed]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install & Run PR–Issue Sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip install -e .
+          python agentic_index_cli/task_daemon.py sync-pr "${{ toJson(github.event) }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,13 @@
 - `agentic_index_cli/internal/issue_logger.py` posts agent logs to issues.
 - Set `GITHUB_TOKEN` so automation jobs can comment on tasks.
 
+## PR–Issue Synchronization
+Pull requests automatically get a tracking issue via
+`.github/workflows/pr-sync.yml`. The workflow triggers on PR creation,
+ready-for-review, and merge events. It runs `agentic_index_cli/task_daemon.py
+sync-pr` with the event payload. The daemon creates a tracking issue when one
+is missing, posts worklog comments to both the PR and the issue, and closes the
+issue when the PR merges. The job requires `GITHUB_TOKEN` with permissions to
+read and write issues and pull requests. Look for a hidden `tracking-issue`
+comment on the PR to find the linked issue number.
+

--- a/tests/test_pr_issue_sync.py
+++ b/tests/test_pr_issue_sync.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+
+import agentic_index_cli.issue_logger as il
+
+
+def _event():
+    return {
+        "action": "opened",
+        "repository": {"full_name": "o/r"},
+        "pull_request": {
+            "number": 1,
+            "title": "T",
+            "body": "b",
+            "html_url": "https://github.com/o/r/pull/1",
+        },
+    }
+
+
+def test_create_issue_for_pr(monkeypatch):
+    event = _event()
+    monkeypatch.setattr(
+        il.requests,
+        "get",
+        lambda *a, **k: type("R", (), {"status_code": 200, "json": lambda self: []})(),
+    )
+    created = {}
+
+    def fake_create(
+        title, body, repo, token=None, labels=None, milestone=None, debug=False
+    ):
+        created["args"] = (title, body, repo)
+        return "https://github.com/o/r/issues/2"
+
+    posted = {}
+
+    def fake_post(url, body, token=None, debug=False):
+        posted["url"] = url
+        posted["body"] = body
+        return "c"
+
+    monkeypatch.setattr(il, "create_issue", fake_create)
+    monkeypatch.setattr(il, "post_comment", fake_post)
+    url = il.create_issue_for_pr(event, token="t")
+    assert url.endswith("/issues/2")
+    assert created["args"][0] == "T"
+    assert posted["url"].endswith("/issues/1")
+    assert "tracking-issue" in posted["body"]
+
+
+def test_create_issue_for_pr_existing(monkeypatch):
+    event = _event()
+
+    def fake_get(*a, **k):
+        return type(
+            "R",
+            (),
+            {
+                "status_code": 200,
+                "json": lambda self: [{"body": "<!-- tracking-issue:3 -->"}],
+            },
+        )()
+
+    monkeypatch.setattr(il.requests, "get", fake_get)
+    url = il.create_issue_for_pr(event, token="t")
+    assert url.endswith("/issues/3")
+
+
+def test_close_issue_for_pr(monkeypatch):
+    event = _event()
+    event["action"] = "closed"
+    event["pull_request"]["merged"] = True
+
+    def fake_get(*a, **k):
+        return type(
+            "R",
+            (),
+            {
+                "status_code": 200,
+                "json": lambda self: [{"body": "<!-- tracking-issue:4 -->"}],
+            },
+        )()
+
+    called = {}
+
+    def fake_post(url, body, token=None, debug=False):
+        called.setdefault("post", []).append((url, body))
+        return "c"
+
+    def fake_close(url, token=None, debug=False):
+        called["close"] = url
+        return "u"
+
+    monkeypatch.setattr(il.requests, "get", fake_get)
+    monkeypatch.setattr(il, "post_comment", fake_post)
+    monkeypatch.setattr(il, "close_issue", fake_close)
+
+    il.close_issue_for_pr(event, token="t")
+    assert called["close"].endswith("/issues/4")
+    assert any("closing" in b for _, b in called["post"])


### PR DESCRIPTION
## Summary
- support auto tracking issues via new workflow
- add utilities for creating and closing PR tracking issues
- handle `sync-pr` command in task daemon
- document PR–issue workflow
- add tests for tracking issue helpers

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ffccd5568832aab9aa71799c4d692