### PR TITLE
Fix CI install step quoting

### DIFF
--- a/.github/workflows/pr-sync.yml
+++ b/.github/workflows/pr-sync.yml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install & Run PR–Issue Sync
+      - name: Smoke test install
+        run: pip install -e .
+      - name: Run PR–Issue Sync
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pip install -e .
-          python agentic_index_cli/task_daemon.py sync-pr "${{ toJson(github.event) }}"
+        run: python agentic_index_cli/task_daemon.py sync-pr '${{ toJson(github.event) }}'


### PR DESCRIPTION
## Summary
- separate install from run step in pr-sync workflow
- quote event JSON properly when invoking PR–Issue sync

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501237ec8c832a8e69416de600f645