### PR TITLE
Implement Issue-First workflow automation

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,13 @@
+name: pr-validate
+
+on: pull_request
+
+jobs:
+  validate-link:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate "Closes #" Link
+        run: |
+          ISSUE_ID=$(yq e '.queue[0].issue_id' .codex/queue.yml)
+          grep -qE "Closes #${ISSUE_ID}\b" <<<"${{ github.event.pull_request.body }}" || (echo "PR must include 'Closes #${ISSUE_ID}' in the description." && exit 1)

--- a/.github/workflows/queue-sync.yml
+++ b/.github/workflows/queue-sync.yml
@@ -1,0 +1,22 @@
+name: queue-sync
+
+on:
+  push:
+    paths:
+      - '.codex/queue.yml'
+
+jobs:
+  sync-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Sync Tasks to Issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          pip install -e .
+          python scripts/sync_queue_to_issues.py .codex/queue.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,19 @@ issue when the PR merges. The job requires `GITHUB_TOKEN` with permissions to
 read and write issues and pull requests. Look for a hidden `tracking-issue`
 comment on the PR to find the linked issue number.
 
+
+## Issue-First Workflow
+The `queue-sync` job converts tasks in `.codex/queue.yml` into GitHub issues.
+Each entry is updated with `issue_id: <number>` after creation.
+Pull requests must reference the associated issue using `Closes #<issue_id>`.
+The `pr-validate` workflow blocks merges if the PR body lacks this link.
+During execution the agent posts worklogs to both the PR and the issue.
+A final log is archived on the issue when it closes.
+
+### Adding Tasks
+Add your task IDs under `queue:` in `.codex/queue.yml`. On push, the
+`queue-sync` workflow creates issues automatically.
+
+### Required Token Scopes
+Automation needs a token with `repo` and `issues` scopes so it can create and
+comment on issues and pull requests.

--- a/agentic_index_cli/task_daemon.py
+++ b/agentic_index_cli/task_daemon.py
@@ -172,7 +172,7 @@ def process_worklogs() -> None:
                 )
                 info["started"] = True
             else:
-                issue_logger.post_worklog_comment(url, data)
+                issue_logger.post_worklog_comment(url, data, targets=["issue", "pr"])
                 info["completed"] = True
                 f.rename(f.with_suffix(".posted"))
         except issue_logger.APIError as exc:

--- a/scripts/sync_queue_to_issues.py
+++ b/scripts/sync_queue_to_issues.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Sync .codex/queue.yml entries to GitHub issues."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from agentic_index_cli import issue_logger
+
+
+def sync_queue(path: Path, repo: str) -> bool:
+    data: Dict[str, Any] = yaml.safe_load(path.read_text()) or {}
+    queue = data.get("queue", [])
+    changed = False
+    new_queue = []
+    for item in queue:
+        if isinstance(item, dict):
+            task_id = item.get("task") or item.get("id")
+            issue_id = item.get("issue_id")
+            entry = dict(item)
+        else:
+            task_id = str(item)
+            issue_id = None
+            entry = {"task": task_id}
+        if not issue_id:
+            title = task_id
+            body = f"Automated task for {task_id}"
+            url = issue_logger.create_issue(title, body, repo)
+            _, num = issue_logger._parse_issue_url(url)
+            entry["issue_id"] = num
+            changed = True
+        new_queue.append(entry)
+    if changed:
+        data["queue"] = new_queue
+        path.write_text(yaml.safe_dump(data))
+    return changed
+
+
+def main(argv: list[str] | None = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+    if not argv:
+        print("Usage: sync_queue_to_issues.py <queue.yml>")
+        sys.exit(1)
+    queue_path = Path(argv[0])
+    repo = os.getenv("GITHUB_REPOSITORY")
+    if not repo:
+        print("GITHUB_REPOSITORY not set", file=sys.stderr)
+        sys.exit(1)
+    sync_queue(queue_path, repo)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_issue_logger.py
+++ b/tests/test_issue_logger.py
@@ -208,3 +208,27 @@ def test_cli_worklog(monkeypatch, tmp_path):
     )
     assert called["url"].endswith("/1")
     assert called["data"] == data
+
+
+@responses.activate
+def test_worklog_targets(monkeypatch):
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/o/r/issues/1/comments",
+        json=[],
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://api.github.com/repos/o/r/issues/1/comments",
+        json={"html_url": "u"},
+        status=201,
+    )
+    data = {"task": "T", "pr_url": "https://api.github.com/repos/o/r/issues/1"}
+    url = il.post_worklog_comment(
+        "https://api.github.com/repos/o/r/issues/1",
+        data,
+        token="t",
+        targets=["pr", "issue"],
+    )
+    assert url == "u"

--- a/tests/test_sync_queue_to_issues.py
+++ b/tests/test_sync_queue_to_issues.py
@@ -1,0 +1,30 @@
+import importlib.util
+import os
+from pathlib import Path
+
+import responses
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "sync_queue_to_issues.py"
+spec = importlib.util.spec_from_file_location("sync_mod", SCRIPT)
+sync_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sync_mod)
+
+
+@responses.activate
+def test_sync_creates_issue(tmp_path, monkeypatch):
+    qfile = tmp_path / "queue.yml"
+    qfile.write_text("queue:\n  - T1\n")
+    os.environ["GITHUB_REPOSITORY"] = "o/r"
+    os.environ["GITHUB_TOKEN"] = "t"
+    responses.add(
+        responses.POST,
+        "https://api.github.com/repos/o/r/issues",
+        json={"html_url": "https://github.com/o/r/issues/1"},
+        status=201,
+    )
+    changed = sync_mod.sync_queue(qfile, "o/r")
+    assert changed
+    data = yaml.safe_load(qfile.read_text())
+    assert data["queue"][0]["issue_id"] == 1

--- a/tests/test_task_daemon.py
+++ b/tests/test_task_daemon.py
@@ -72,7 +72,7 @@ def test_process_worklogs(monkeypatch, tmp_path):
     )
     called = {}
 
-    def fake_post(url, d):
+    def fake_post(url, d, **kw):
         called["url"] = url
         called["data"] = d
 


### PR DESCRIPTION
## Summary
- add queue-sync workflow to open issues for tasks
- validate PR descriptions contain `Closes #<issue_id>`
- allow worklogs to post to both PR and issue
- add script to sync queue entries to issues
- document issue-first workflow
- test queue syncing and new logging behavior

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850155291c8832a8ebed5dc6bc569e6