### PR TITLE
Enhance README injector robustness

### DIFF
--- a/agentic_index_api/main.py
+++ b/agentic_index_api/main.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from fastapi import FastAPI, HTTPException
 
-DATA_FILE = Path("repos.json")
+DATA_FILE = Path("data/repos.json")
 HISTORY_DIR = Path("data/history")
 
 app = FastAPI(title="Agentic Index API")

--- a/agentic_index_cli/inject_readme.py
+++ b/agentic_index_cli/inject_readme.py
@@ -1,6 +1,6 @@
 """Helpers for injecting the top-50 table into ``README.md``."""
 
-from .internal.inject_readme import main
+from .internal.inject_readme import DEFAULT_TOP_N, main
 
 
 def cli(argv=None):
@@ -9,8 +9,9 @@ def cli(argv=None):
 
     parser = argparse.ArgumentParser(description="Inject README table")
     parser.add_argument("--force", action="store_true")
+    parser.add_argument("--top-n", type=int, default=DEFAULT_TOP_N)
     args = parser.parse_args(argv)
-    main(force=args.force)
+    main(force=args.force, top_n=args.top_n)
 
 
 if __name__ == "__main__":

--- a/repos.json
+++ b/repos.json
@@ -1,1 +1,0 @@
-{"repos": [{"name": "repo1", "AgentOpsScore": 10}, {"name": "repo2", "AgentOpsScore": 9}, {"name": "repo3", "AgentOpsScore": 8}, {"name": "repo4", "AgentOpsScore": 7}, {"name": "repo5", "AgentOpsScore": 6}]}

--- a/scripts/inject_readme.py
+++ b/scripts/inject_readme.py
@@ -5,7 +5,11 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from agentic_index_cli.internal.inject_readme import DEFAULT_SORT_FIELD, main
+from agentic_index_cli.internal.inject_readme import (
+    DEFAULT_SORT_FIELD,
+    DEFAULT_TOP_N,
+    main,
+)
 
 if __name__ == "__main__":
     import argparse
@@ -31,8 +35,15 @@ if __name__ == "__main__":
         choices=["overall", "stars_7d", "maintenance", "last_release"],
         help="Sort table by metric",
     )
+    parser.add_argument("--top-n", type=int, default=DEFAULT_TOP_N)
     args = parser.parse_args()
 
     check = args.check or args.dry_run
     write = args.write or not check
-    main(force=args.force, check=check, write=write, sort_by=args.sort_by)
+    main(
+        force=args.force,
+        check=check,
+        write=write,
+        sort_by=args.sort_by,
+        top_n=args.top_n,
+    )

--- a/scripts/scrape_repos.py
+++ b/scripts/scrape_repos.py
@@ -175,12 +175,15 @@ def scrape(repos: List[str], min_stars: int = 0) -> List[Dict[str, Any]]:
 
 
 def main(argv: List[str] | None = None) -> None:
+    global DELTA_DAYS
     parser = argparse.ArgumentParser(description="Scrape GitHub repos")
     parser.add_argument("--one-shot", action="store_true", help="fetch once")
     parser.add_argument("--repos", nargs="*", default=DEFAULT_REPOS)
     parser.add_argument("--min-stars", type=int, default=0)
     parser.add_argument("--output", default="data/repos.json")
+    parser.add_argument("--delta-days", type=int, default=DELTA_DAYS)
     args = parser.parse_args(argv)
+    DELTA_DAYS = args.delta_days
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,8 +1,21 @@
 from fastapi.testclient import TestClient
 
-from agentic_index_api.main import app
+from agentic_index_api import main as api_main
 
-client = TestClient(app)
+api_main.REPOS[:] = [
+    {
+        "name": "repo1",
+        "full_name": "repo1",
+        "stargazers_count": 1,
+        "AgenticIndexScore": 1.0,
+    }
+]
+api_main.RANKED[:] = api_main.REPOS[:]
+api_main.NAME_MAP.clear()
+for r in api_main.REPOS:
+    api_main.NAME_MAP[r["name"]] = r
+
+client = TestClient(api_main.app)
 
 
 def test_repo_endpoint():

--- a/tests/test_cli_wrappers.py
+++ b/tests/test_cli_wrappers.py
@@ -35,12 +35,14 @@ def test_ranker_cli(monkeypatch, tmp_path):
 def test_inject_cli(monkeypatch):
     called = {}
 
-    def fake_main(force=False):
+    def fake_main(force=False, top_n=100):
         called["force"] = force
+        called["top_n"] = top_n
 
     monkeypatch.setattr(inject, "main", fake_main)
     inject.cli(["--force"])
     assert called["force"] is True
+    assert called["top_n"] == 100
 
 
 def test_generate_outputs(monkeypatch):

--- a/tests/test_inject_cli_script.py
+++ b/tests/test_inject_cli_script.py
@@ -6,12 +6,12 @@ from pathlib import Path
 def test_inject_script_check(monkeypatch, tmp_path):
     calls = {}
 
-    def fake_main(force=False, check=False, write=True, sort_by="overall"):
-        calls["args"] = (force, check, write, sort_by)
+    def fake_main(force=False, check=False, write=True, sort_by="overall", top_n=100):
+        calls["args"] = (force, check, write, sort_by, top_n)
         return 0
 
     monkeypatch.setattr("agentic_index_cli.internal.inject_readme.main", fake_main)
     script = Path(__file__).resolve().parents[1] / "scripts" / "inject_readme.py"
     sys.argv = [str(script), "--check"]
     runpy.run_path(script, run_name="__main__")
-    assert calls["args"] == (False, True, False, "overall")
+    assert calls["args"] == (False, True, False, "overall", 100)

--- a/tests/test_inject_markers.py
+++ b/tests/test_inject_markers.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 import agentic_index_cli.internal.inject_readme as inj
 
 
@@ -14,4 +16,25 @@ def test_missing_markers(tmp_path, monkeypatch):
 
     monkeypatch.setattr(inj, "README_PATH", readme)
     monkeypatch.setattr(inj, "DATA_PATH", data_dir / "top100.md")
-    assert inj.main() == 1
+    assert inj.main(top_n=50) == 1
+
+
+def test_marker_mismatch(tmp_path, monkeypatch):
+    readme = tmp_path / "README.md"
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "repos.json").write_text('{"schema_version":2,"repos":[]}')
+    (data_dir / "top100.md").write_text("")
+    (data_dir / "last_snapshot.json").write_text("[]")
+    readme.write_text("start\n<!-- TOP50:START -->\n<!-- TOP50:END -->\n")
+
+    for name, val in {
+        "README_PATH": readme,
+        "DATA_PATH": data_dir / "top100.md",
+        "REPOS_PATH": data_dir / "repos.json",
+        "SNAPSHOT": data_dir / "last_snapshot.json",
+    }.items():
+        setattr(inj, name, val)
+
+    with pytest.raises(ValueError, match="TOP100:START"):
+        inj.build_readme(top_n=100)

--- a/tests/test_inject_readme_cli.py
+++ b/tests/test_inject_readme_cli.py
@@ -4,9 +4,11 @@ import agentic_index_cli.inject_readme as ir
 def test_cli_forwards_force(monkeypatch):
     called = {}
 
-    def fake_main(force=False):
+    def fake_main(force=False, top_n=100):
         called["force"] = force
+        called["top_n"] = top_n
 
     monkeypatch.setattr(ir, "main", fake_main)
     ir.cli(["--force"])
     assert called["force"] is True
+    assert called["top_n"] == 100

--- a/tests/test_inject_script.py
+++ b/tests/test_inject_script.py
@@ -10,7 +10,7 @@ def test_inject_readme(tmp_path, monkeypatch):
     table = '| Rank | <abbr title="Overall">📊</abbr> Overall | Repo | <abbr title="Stars gained in last 7 days">⭐ Δ7d</abbr> | <abbr title="Maintenance score">🔧 Maint</abbr> | <abbr title="Last release date">📅 Release</abbr> | <abbr title="Documentation score">📚 Docs</abbr> | <abbr title="Ecosystem fit">🧠 Fit</abbr> | <abbr title="License">⚖️ License</abbr> |\n|-----:|------:|------|-------:|-------:|-----------|-------:|-------:|---------|\n| 1 | 1.00 | x | 1 | 0.50 | - | 0.50 | 0.30 | MIT |\n'
     (data_dir / "top100.md").write_text(table)
     (data_dir / "repos.json").write_text(
-        '{"schema_version":2,"repos":[{"name":"x","full_name":"o/x","AgenticIndexScore":1.0,"stars_7d":1,"maintenance":0.5,"docs_score":0.5,"ecosystem":0.3,"last_release":null,"license":"MIT"}]}'
+        '{"schema_version":2,"repos":[{"name":"x","full_name":"o/x","AgenticIndexScore":1.0,"stars_7d":1,"maintenance":0.5,"docs_score":0.5,"ecosystem":0.3,"last_release":null,"license":"MIT","score_delta":0}]}'
     )
 
     monkeypatch.setattr(inj, "REPOS_PATH", data_dir / "repos.json")
@@ -21,7 +21,7 @@ def test_inject_readme(tmp_path, monkeypatch):
     monkeypatch.setattr(inj, "README_PATH", readme)
     monkeypatch.setattr(inj, "DATA_PATH", data_dir / "top100.md")
 
-    assert inj.main() == 0
+    assert inj.main(top_n=50) == 0
     content = readme.read_text()
     assert "| 1 | 1.00 | x |" in content
     assert content.count("<!-- TOP50:START -->") == 1

--- a/tests/test_no_zero_metrics.py
+++ b/tests/test_no_zero_metrics.py
@@ -16,6 +16,7 @@ def _setup(tmp_path: Path):
             "AgenticIndexScore": 1.0,
             "stars_7d": 0,
             "license": "MIT",
+            "score_delta": 0,
         },
         {
             "name": "b",
@@ -26,6 +27,7 @@ def _setup(tmp_path: Path):
             "docs_score": 0.5,
             "ecosystem": 0.2,
             "license": "MIT",
+            "score_delta": 0,
         },
     ]
     (data_dir / "repos.json").write_text(
@@ -47,7 +49,7 @@ def _setup(tmp_path: Path):
 
 def test_no_all_zero_rows(tmp_path):
     _setup(tmp_path)
-    text = inj.build_readme()
+    text = inj.build_readme(top_n=50)
     lines = [l for l in text.splitlines() if l.startswith("|")][2:]
     for line in lines:
         parts = [p.strip() for p in line.split("|")]

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -98,7 +98,7 @@ def test_end_to_end(tmp_path, monkeypatch, min_stars):
     }.items():
         setattr(inj_mod, name, val)
 
-    inj_mod.main(force=True)
+    inj_mod.main(force=True, top_n=50)
 
     text = readme.read_text()
     assert "| 1 |" in text

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -20,6 +20,7 @@ def _setup(tmp_path: Path):
             "ecosystem": 0.0,
             "last_release": "2025-06-01T00:00:00Z",
             "license": "MIT",
+            "score_delta": 0,
         },
         {
             "name": "B",
@@ -31,6 +32,7 @@ def _setup(tmp_path: Path):
             "ecosystem": 0.0,
             "last_release": "2025-05-01T00:00:00Z",
             "license": "MIT",
+            "score_delta": 0,
         },
     ]
     (data_dir / "repos.json").write_text(
@@ -62,13 +64,13 @@ def _setup(tmp_path: Path):
 )
 def test_sort_order(tmp_path, field, first):
     _setup(tmp_path)
-    text = inj.build_readme(sort_by=field)
+    text = inj.build_readme(sort_by=field, top_n=50)
     lines = [l for l in text.splitlines() if l.startswith("|")][2:]
     assert lines[0].split("|")[3].strip() == first
 
 
 def test_stable_between_runs(tmp_path):
     _setup(tmp_path)
-    first = inj.build_readme(sort_by="stars_7d")
-    second = inj.build_readme(sort_by="stars_7d")
+    first = inj.build_readme(sort_by="stars_7d", top_n=50)
+    second = inj.build_readme(sort_by="stars_7d", top_n=50)
     assert first == second

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -6,7 +6,7 @@ INJECT = ROOT / "scripts" / "inject_readme.py"
 
 
 def test_readme_synced():
-    subprocess.run(["python", str(INJECT), "--check"], check=True)
+    subprocess.run(["python", str(INJECT), "--check", "--top-n", "50"], check=True)
 
     text = (ROOT / "README.md").read_text()
     start = text.index("<!-- TOP50:START -->")
@@ -27,7 +27,7 @@ def test_readme_synced():
 
 
 def test_inject_idempotent(tmp_path):
-    subprocess.run(["python", str(INJECT)], check=True)
+    subprocess.run(["python", str(INJECT), "--top-n", "50"], check=True)
     first = (ROOT / "README.md").read_text()
-    subprocess.run(["python", str(INJECT)], check=True)
+    subprocess.run(["python", str(INJECT), "--top-n", "50"], check=True)
     assert (ROOT / "README.md").read_text() == first


### PR DESCRIPTION
Closes #85

## Summary
- allow configurable `--top-n` for injection scripts
- validate required repo fields and raise clear errors
- expose `--delta-days` for scraping
- drop root `repos.json`
- update tests for stricter checking

## Testing
- `bash scripts/agent-setup.sh`
- `PYTHONPATH="$PWD" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68503299dc98832a973b2c59568fb403