### PR TITLE
Add enrichment fields with schema validation

### DIFF
--- a/agentic_index_cli/enricher.py
+++ b/agentic_index_cli/enricher.py
@@ -1,16 +1,43 @@
 """Helpers for enriching scraped repository data."""
 
 import argparse
+import json
 import math
 from pathlib import Path
 
-from .agentic_index import compute_issue_health, compute_recency_factor, license_freedom
+from jsonschema import Draft7Validator
+
+from .agentic_index import (
+    categorize,
+    compute_issue_health,
+    compute_recency_factor,
+    license_freedom,
+)
 from .validate import load_repos, save_repos
+
+
+def _previous_map(data_file: Path) -> dict:
+    """Return repo mapping from the last snapshot if available."""
+    history_dir = data_file.parent / "history"
+    last = data_file.parent / "last_snapshot.txt"
+    if not last.exists():
+        return {}
+    prev_path = Path(last.read_text().strip())
+    if not prev_path.is_absolute():
+        prev_path = history_dir / prev_path.name
+    if not prev_path.exists():
+        return {}
+    try:
+        prev_repos = load_repos(prev_path)
+    except Exception:
+        return {}
+    return {r.get("full_name", r.get("name")): r for r in prev_repos}
 
 
 def enrich(path: Path) -> None:
     """Add derived fields to a repository JSON file."""
     data = load_repos(path)
+    prev_map = _previous_map(path)
     for repo in data:
         stars = repo.get("stargazers_count", 0)
         repo["stars"] = stars
@@ -26,8 +53,41 @@ def enrich(path: Path) -> None:
         if isinstance(lic, dict):
             lic = lic.get("spdx_id")
         repo["license_freedom"] = license_freedom(lic)
+        if lic is not None:
+            repo["license"] = {"spdx_id": lic}
+        else:
+            repo["license"] = None
         repo.setdefault("ecosystem_integration", 0.0)
+        repo["category"] = categorize(
+            repo.get("description", ""), repo.get("topics", [])
+        )
+        prev = prev_map.get(repo.get("full_name", repo.get("name")))
+        if prev:
+            repo["stars_delta"] = stars - prev.get(
+                "stars", prev.get("stargazers_count", 0)
+            )
+            repo["score_delta"] = round(
+                float(repo.get("AgenticIndexScore", 0))
+                - float(prev.get("AgenticIndexScore", 0)),
+                2,
+            )
+        else:
+            repo["stars_delta"] = 0
+            repo["score_delta"] = 0.0
+
     save_repos(path, data)
+
+    schema_path = Path(__file__).resolve().parents[1] / "schemas" / "repo.schema.json"
+    schema = json.loads(schema_path.read_text())
+    validator = Draft7Validator(schema)
+    saved = json.loads(path.read_text())
+    repos = saved.get("repos", saved)
+    for item in repos:
+        lic = item.get("license")
+        if isinstance(lic, str):
+            item = dict(item)
+            item["license"] = {"spdx_id": lic}
+        validator.validate(item)
 
 
 def main(argv=None):

--- a/tests/test_enricher.py
+++ b/tests/test_enricher.py
@@ -1,5 +1,8 @@
 import json
 import subprocess
+from pathlib import Path
+
+from jsonschema import Draft7Validator
 
 
 def test_enrich_schema(tmp_path):
@@ -34,5 +37,16 @@ def test_enrich_schema(tmp_path):
         "license_freedom",
         "ecosystem_integration",
         "stars",
+        "stars_delta",
+        "score_delta",
+        "category",
     ]:
         assert key in repo
+
+    schema_path = Path(__file__).resolve().parents[1] / "schemas" / "repo.schema.json"
+    schema = json.loads(schema_path.read_text())
+    lic = repo.get("license")
+    if isinstance(lic, str):
+        repo = dict(repo)
+        repo["license"] = {"spdx_id": lic}
+    Draft7Validator(schema).validate(repo)


### PR DESCRIPTION
Closes #CR-AI-106B

## Summary
- compute additional enrichment fields in `enricher.py`
- validate output against `repo.schema.json`
- update test to cover new fields

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850521de0d4832a941767f05256292c