### PR TITLE
Update README injection for schema v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,108 +99,58 @@ The definitive list of Agentic-AI repositories, ranked by the Agentic Index Scor
 *(Data updated as of: 2025-06-16T05:56:02 UTC)*
 
 <!-- TOP50:START -->
-| Rank | <abbr title="Overall">📊</abbr> Overall | Repo | <abbr title="Stars gained in last 7 days">⭐ Δ7d</abbr> | <abbr title="Maintenance score">🔧 Maint</abbr> | <abbr title="Last release date">📅 Release</abbr> | <abbr title="Documentation score">📚 Docs</abbr> | <abbr title="Ecosystem fit">🧠 Fit</abbr> | <abbr title="License">⚖️ License</abbr> |
-|-----:|------:|------|-------:|-------:|-----------|-------:|-------:|---------|
-| 1 | 5.28 | dify | 0 | - | - | - | - | NOASSERTION |
-| 2 | 5.17 | langflow | 0 | - | - | - | - | MIT |
-| 3 | 5.10 | browser-use | 0 | - | - | - | - | MIT |
-| 4 | 5.07 | OpenHands | 0 | - | - | - | - | MIT |
-| 5 | 5.06 | lobe-chat | 0 | - | - | - | - | NOASSERTION |
-| 6 | 5.06 | MetaGPT | 0 | - | - | - | - | MIT |
-| 7 | 5.04 | ragflow | 0 | - | - | - | - | Apache-2.0 |
-| 8 | 5.03 | system-prompts-and-models... | 0 | - | - | - | - | GPL-3.0 |
-| 9 | 5.02 | LLaMA-Factory | 0 | - | - | - | - | Apache-2.0 |
-| 10 | 4.96 | anything-llm | 0 | - | - | - | - | MIT |
-| 11 | 4.96 | cline | 0 | - | - | - | - | Apache-2.0 |
-| 12 | 4.93 | autogen | 0 | - | - | - | - | CC-BY-4.0 |
-| 13 | 4.93 | llama_index | 0 | - | - | - | - | MIT |
-| 14 | 4.92 | awesome-llm-apps | 0 | - | - | - | - | Apache-2.0 |
-| 15 | 4.87 | Flowise | 0 | - | - | - | - | NOASSERTION |
-| 16 | 4.84 | ChatTTS | 0 | - | - | - | - | AGPL-3.0 |
-| 17 | 4.84 | mem0 | 0 | - | - | - | - | Apache-2.0 |
-| 18 | 4.82 | crewAI | 0 | - | - | - | - | MIT |
-| 19 | 4.81 | Langchain-Chatchat | 0 | - | - | - | - | Apache-2.0 |
-| 20 | 4.79 | AgentGPT | 0 | - | - | - | - | GPL-3.0 |
-| 21 | 4.76 | agno | 0 | - | - | - | - | MPL-2.0 |
-| 22 | 4.75 | khoj | 0 | - | - | - | - | AGPL-3.0 |
-| 23 | 4.74 | ChatDev | 0 | - | - | - | - | Apache-2.0 |
-| 24 | 4.73 | ai-agents-for-beginners | 0 | - | - | - | - | MIT |
-| 25 | 4.73 | LibreChat | 0 | - | - | - | - | MIT |
-| 26 | 4.72 | cherry-studio | 0 | - | - | - | - | NOASSERTION |
-| 27 | 4.72 | Jobs_Applier_AI_Agent_AIHawk | 0 | - | - | - | - | AGPL-3.0 |
-| 28 | 4.71 | qlib | 0 | - | - | - | - | MIT |
-| 29 | 4.68 | composio | 0 | - | - | - | - | NOASSERTION |
-| 30 | 4.66 | FastGPT | 0 | - | - | - | - | NOASSERTION |
-| 31 | 4.65 | gpt-researcher | 0 | - | - | - | - | Apache-2.0 |
-| 32 | 4.63 | CopilotKit | 0 | - | - | - | - | MIT |
-| 33 | 4.63 | haystack | 0 | - | - | - | - | Apache-2.0 |
-| 34 | 4.56 | swarm | 0 | - | - | - | - | MIT |
-| 35 | 4.55 | agentic | 0 | - | - | - | - | MIT |
-| 36 | 4.54 | vanna | 0 | - | - | - | - | MIT |
-| 37 | 4.53 | agenticSeek | 0 | - | - | - | - | GPL-3.0 |
-| 38 | 4.53 | DB-GPT | 0 | - | - | - | - | MIT |
-| 39 | 4.53 | deep-research | 0 | - | - | - | - | MIT |
-| 40 | 4.53 | letta | 0 | - | - | - | - | Apache-2.0 |
-| 41 | 4.52 | SWE-agent | 0 | - | - | - | - | MIT |
-| 42 | 4.51 | eliza | 0 | - | - | - | - | MIT |
-| 43 | 4.51 | RagaAI-Catalyst | 0 | - | - | - | - | Apache-2.0 |
-| 44 | 4.50 | DocsGPT | 0 | - | - | - | - | MIT |
-| 45 | 4.48 | awesome-ai-agents | 0 | - | - | - | - | NOASSERTION |
-| 46 | 4.47 | goose | 0 | - | - | - | - | Apache-2.0 |
-| 47 | 4.46 | activepieces | 0 | - | - | - | - | NOASSERTION |
-| 48 | 4.46 | suna | 0 | - | - | - | - | Apache-2.0 |
-| 49 | 4.45 | ai | 0 | - | - | - | - | NOASSERTION |
-| 50 | 4.45 | botpress | 0 | - | - | - | - | MIT |
-| 51 | 4.45 | dagger | 0 | - | - | - | - | Apache-2.0 |
-| 52 | 4.45 | plandex | 0 | - | - | - | - | MIT |
-| 53 | 4.44 | ai-pdf-chatbot-langchain | 0 | - | - | - | - | MIT |
-| 54 | 4.44 | deer-flow | 0 | - | - | - | - | MIT |
-| 55 | 4.44 | SuperAGI | 0 | - | - | - | - | MIT |
-| 56 | 4.44 | web-ui | 0 | - | - | - | - | MIT |
-| 57 | 4.42 | camel | 0 | - | - | - | - | Apache-2.0 |
-| 58 | 4.42 | mastra | 0 | - | - | - | - | NOASSERTION |
-| 59 | 4.41 | ChuanhuChatGPT | 0 | - | - | - | - | GPL-3.0 |
-| 60 | 4.41 | devika | 0 | - | - | - | - | MIT |
-| 61 | 4.39 | GenAI_Agents | 0 | - | - | - | - | NOASSERTION |
-| 62 | 4.37 | Llama-Chinese | 0 | - | - | - | - | - |
-| 63 | 4.36 | graphiti | 0 | - | - | - | - | Apache-2.0 |
-| 64 | 4.36 | openai-agents-python | 0 | - | - | - | - | MIT |
-| 65 | 4.35 | LangBot | 0 | - | - | - | - | AGPL-3.0 |
-| 66 | 4.32 | pydantic-ai | 0 | - | - | - | - | MIT |
-| 67 | 4.31 | adk-python | 0 | - | - | - | - | Apache-2.0 |
-| 68 | 4.30 | ai-engineering-hub | 0 | - | - | - | - | MIT |
-| 69 | 4.29 | opik | 0 | - | - | - | - | Apache-2.0 |
-| 70 | 4.29 | Qwen-Agent | 0 | - | - | - | - | Apache-2.0 |
-| 71 | 4.27 | agent-zero | 0 | - | - | - | - | NOASSERTION |
-| 72 | 4.26 | AstrBot | 0 | - | - | - | - | AGPL-3.0 |
-| 73 | 4.25 | bisheng | 0 | - | - | - | - | Apache-2.0 |
-| 74 | 4.24 | awesome-LLM-resources | 0 | - | - | - | - | Apache-2.0 |
-| 75 | 4.24 | cua | 0 | - | - | - | - | MIT |
-| 76 | 4.24 | E2B | 0 | - | - | - | - | Apache-2.0 |
-| 77 | 4.22 | Figma-Context-MCP | 0 | - | - | - | - | MIT |
-| 78 | 4.20 | Bert-VITS2 | 0 | - | - | - | - | AGPL-3.0 |
-| 79 | 4.18 | agentscope | 0 | - | - | - | - | Apache-2.0 |
-| 80 | 4.18 | pr-agent | 0 | - | - | - | - | AGPL-3.0 |
-| 81 | 4.18 | UFO | 0 | - | - | - | - | MIT |
-| 82 | 4.18 | Upsonic | 0 | - | - | - | - | MIT |
-| 83 | 4.18 | WrenAI | 0 | - | - | - | - | AGPL-3.0 |
-| 84 | 4.16 | OpenRLHF | 0 | - | - | - | - | Apache-2.0 |
-| 85 | 4.16 | promptfoo | 0 | - | - | - | - | MIT |
-| 86 | 4.15 | aichat | 0 | - | - | - | - | Apache-2.0 |
-| 87 | 4.15 | R2R | 0 | - | - | - | - | MIT |
-| 88 | 4.14 | nanobrowser | 0 | - | - | - | - | Apache-2.0 |
-| 89 | 4.11 | agents | 0 | - | - | - | - | Apache-2.0 |
-| 90 | 4.11 | intentkit | 0 | - | - | - | - | MIT |
-| 91 | 4.10 | deep-searcher | 0 | - | - | - | - | Apache-2.0 |
-| 92 | 4.09 | agent-squad | 0 | - | - | - | - | Apache-2.0 |
-| 93 | 4.08 | lamda | 0 | - | - | - | - | - |
-| 94 | 4.08 | RD-Agent | 0 | - | - | - | - | MIT |
-| 95 | 4.07 | LLocalSearch | 0 | - | - | - | - | Apache-2.0 |
-| 96 | 4.07 | TaskWeaver | 0 | - | - | - | - | MIT |
-| 97 | 4.06 | mcp-agent | 0 | - | - | - | - | Apache-2.0 |
-| 98 | 4.06 | ten-framework | 0 | - | - | - | - | NOASSERTION |
-| 99 | 4.05 | cognee | 0 | - | - | - | - | Apache-2.0 |
-| 100 | 4.05 | julep | 0 | - | - | - | - | Apache-2.0 |
+| Rank | Repo | Score | Stars | Δ Stars | Δ Score | Recency | Issue Health | Doc Complete | License Freedom | Ecosystem | log₂(Stars) | Category |
+|-----:|------|------:|------:|--------:|--------:|-------:|-------------:|-------------:|---------------:|---------:|------------:|----------|
+| 1 | dify | 5.28 | 103268 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 16.66 | General-purpose |
+| 2 | langflow | 5.17 | 73776 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 16.17 | DevTools |
+| 3 | browser-use | 5.10 | 63197 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.95 | General-purpose |
+| 4 | OpenHands | 5.07 | 58086 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.83 | General-purpose |
+| 5 | lobe-chat | 5.06 | 62457 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 15.93 | RAG-centric |
+| 6 | MetaGPT | 5.06 | 56406 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.78 | Multi-Agent Coordination |
+| 7 | ragflow | 5.04 | 55104 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.75 | RAG-centric |
+| 8 | system-prompts-and-models... | 5.03 | 57495 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 15.81 | DevTools |
+| 9 | LLaMA-Factory | 5.02 | 52281 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.67 | General-purpose |
+| 10 | anything-llm | 4.96 | 45309 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.47 | RAG-centric |
+| 11 | cline | 4.96 | 45704 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.48 | General-purpose |
+| 12 | autogen | 4.93 | 45993 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 15.49 | General-purpose |
+| 13 | llama_index | 4.93 | 42355 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.37 | General-purpose |
+| 14 | awesome-llm-apps | 4.92 | 41125 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.33 | RAG-centric |
+| 15 | Flowise | 4.87 | 40065 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 15.29 | General-purpose |
+| 16 | ChatTTS | 4.84 | 36799 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 15.17 | General-purpose |
+| 17 | mem0 | 4.84 | 34513 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.07 | General-purpose |
+| 18 | crewAI | 4.82 | 32933 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.01 | Multi-Agent Coordination |
+| 19 | Langchain-Chatchat | 4.81 | 35287 | +new | +new | 0.84 | 0.00 | 0.00 | 1.00 | 0.00 | 15.11 | RAG-centric |
+| 20 | AgentGPT | 4.79 | 34323 | +new | +new | 0.95 | 0.00 | 0.00 | 0.50 | 0.00 | 15.07 | General-purpose |
+| 21 | agno | 4.76 | 28280 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.79 | Multi-Agent Coordination |
+| 22 | khoj | 4.75 | 30327 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.89 | Experimental |
+| 23 | ChatDev | 4.74 | 27024 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.72 | Multi-Agent Coordination |
+| 24 | ai-agents-for-beginners | 4.73 | 26615 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.70 | General-purpose |
+| 25 | LibreChat | 4.73 | 26789 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.71 | General-purpose |
+| 26 | cherry-studio | 4.72 | 28444 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.80 | General-purpose |
+| 27 | Jobs_Applier_AI_Agent_AIHawk | 4.72 | 28310 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.79 | General-purpose |
+| 28 | qlib | 4.71 | 25192 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.62 | Experimental |
+| 29 | composio | 4.68 | 25499 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.64 | General-purpose |
+| 30 | FastGPT | 4.66 | 24718 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.59 | RAG-centric |
+| 31 | gpt-researcher | 4.65 | 21875 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.42 | Experimental |
+| 32 | CopilotKit | 4.63 | 21205 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.37 | General-purpose |
+| 33 | haystack | 4.63 | 21154 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.37 | RAG-centric |
+| 34 | swarm | 4.56 | 19920 | +new | +new | 0.80 | 0.00 | 0.00 | 1.00 | 0.00 | 14.28 | Multi-Agent Coordination |
+| 35 | agentic | 4.55 | 17639 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.11 | General-purpose |
+| 36 | vanna | 4.54 | 18127 | +new | +new | 0.89 | 0.00 | 0.00 | 1.00 | 0.00 | 14.15 | RAG-centric |
+| 37 | agenticSeek | 4.53 | 18268 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.16 | General-purpose |
+| 38 | DB-GPT | 4.53 | 16764 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.03 | General-purpose |
+| 39 | deep-research | 4.53 | 16638 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.02 | Experimental |
+| 40 | letta | 4.53 | 16861 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.04 | General-purpose |
+| 41 | SWE-agent | 4.52 | 16305 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.99 | General-purpose |
+| 42 | eliza | 4.51 | 16078 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.97 | General-purpose |
+| 43 | RagaAI-Catalyst | 4.51 | 16193 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.98 | RAG-centric |
+| 44 | DocsGPT | 4.50 | 15708 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.94 | DevTools |
+| 45 | awesome-ai-agents | 4.48 | 18587 | +new | +new | 0.76 | 0.00 | 0.00 | 0.50 | 0.00 | 14.18 | General-purpose |
+| 46 | goose | 4.47 | 14627 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.84 | General-purpose |
+| 47 | activepieces | 4.46 | 15291 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 13.90 | General-purpose |
+| 48 | suna | 4.46 | 14425 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.82 | General-purpose |
+| 49 | ai | 4.45 | 14955 | +new | +new | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 13.87 | DevTools |
+| 50 | botpress | 4.45 | 13805 | +new | +new | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.75 | General-purpose |
 <!-- TOP50:END -->
 *➡️ Dig into how these scores are cooked up in our [Methodology section](#our-methodology--scoring-explained) and the [full recipe in /docs/methodology.md](./docs/methodology.md).*
 

--- a/scripts/inject_readme.py
+++ b/scripts/inject_readme.py
@@ -32,10 +32,18 @@ if __name__ == "__main__":
     parser.add_argument(
         "--sort-by",
         default=DEFAULT_SORT_FIELD,
-        choices=["overall", "stars_7d", "maintenance", "last_release"],
+        choices=[
+            "score",
+            "stars",
+            "stars_delta",
+            "score_delta",
+            "recency",
+            "issue_health",
+        ],
         help="Sort table by metric",
     )
     parser.add_argument("--top-n", type=int, default=DEFAULT_TOP_N)
+    parser.add_argument("--limit", type=int, help="Maximum rows to render")
     args = parser.parse_args()
 
     check = args.check or args.dry_run
@@ -46,4 +54,5 @@ if __name__ == "__main__":
         write=write,
         sort_by=args.sort_by,
         top_n=args.top_n,
+        limit=args.limit,
     )

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -71,10 +71,10 @@ def assert_readme_diff(old: str, new: str, *, delta: float = 0.02) -> None:
 
         if ocells[0] != ncells[0]:
             errors.append(f"rank {ocells[0]} != {ncells[0]}")
-        if ocells[2] != ncells[2]:
-            errors.append(f"repo '{ocells[2]}' != '{ncells[2]}'")
+        if ocells[1] != ncells[1]:
+            errors.append(f"repo '{ocells[1]}' != '{ncells[1]}'")
 
-        for idx in (1, 3, 4, 6, 7):
+        for idx in range(2, 12):
             if ocells[idx] and ncells[idx]:
                 try:
                     if abs(float(ocells[idx]) - float(ncells[idx])) > delta:
@@ -82,10 +82,5 @@ def assert_readme_diff(old: str, new: str, *, delta: float = 0.02) -> None:
                 except ValueError:
                     if ocells[idx] != ncells[idx]:
                         errors.append(f"col {idx} '{ocells[idx]}' != '{ncells[idx]}'")
-
-        if ocells[5] != ncells[5]:
-            errors.append(f"release '{ocells[5]}' != '{ncells[5]}'")
-        if ocells[8] != ncells[8]:
-            errors.append(f"license '{ocells[8]}' != '{ncells[8]}'")
 
         assert not errors, f"row {i}: " + "; ".join(errors)

--- a/tests/fixtures/README_fixture.md
+++ b/tests/fixtures/README_fixture.md
@@ -96,111 +96,61 @@ New to Agentic-AI or just want the good stuff fast? These repos are top-tier for
 ## 🏆 The Agentic-Index Top 100: AI Agent Repositories
 
 The definitive list of Agentic-AI repositories, ranked by the Agentic Index Score. This score is a holistic measure of project quality, activity, and community love.
-*(Data updated as of: {timestamp} UTC)*
+*(Data updated as of: 2025-06-16T17:39:49 UTC)*
 
 <!-- TOP50:START -->
-| Rank | <abbr title="Overall">📊</abbr> Overall | Repo | <abbr title="Stars gained in last 7 days">⭐ Δ7d</abbr> | <abbr title="Maintenance score">🔧 Maint</abbr> | <abbr title="Last release date">📅 Release</abbr> | <abbr title="Documentation score">📚 Docs</abbr> | <abbr title="Ecosystem fit">🧠 Fit</abbr> | <abbr title="License">⚖️ License</abbr> |
-|-----:|------:|------|-------:|-------:|-----------|-------:|-------:|---------|
-| 1 | 6.08 | dify | 123 | 0.90 | 2025-06-01 | 0.80 | 0.70 | NOASSERTION |
-| 2 | 5.96 | langflow | 0 | - | - | - | - | MIT |
-| 3 | 5.88 | browser-use | 0 | - | - | - | - | MIT |
-| 4 | 5.84 | OpenHands | 0 | - | - | - | - | MIT |
-| 5 | 5.83 | lobe-chat | 0 | - | - | - | - | NOASSERTION |
-| 6 | 5.82 | MetaGPT | 0 | - | - | - | - | MIT |
-| 7 | 5.81 | ragflow | 0 | - | - | - | - | Apache-2.0 |
-| 8 | 5.79 | LLaMA-Factory | 0 | - | - | - | - | Apache-2.0 |
-| 9 | 5.78 | system-prompts-and-models... | 0 | - | - | - | - | GPL-3.0 |
-| 10 | 5.72 | cline | 0 | - | - | - | - | Apache-2.0 |
-| 11 | 5.71 | anything-llm | 0 | - | - | - | - | MIT |
-| 12 | 5.68 | llama_index | 0 | - | - | - | - | MIT |
-| 13 | 5.67 | autogen | 0 | - | - | - | - | CC-BY-4.0 |
-| 14 | 5.63 | awesome-llm-apps | 0 | - | - | - | - | Apache-2.0 |
-| 15 | 5.60 | Flowise | 0 | - | - | - | - | NOASSERTION |
-| 16 | 5.57 | mem0 | 0 | - | - | - | - | Apache-2.0 |
-| 17 | 5.56 | ChatTTS | 0 | - | - | - | - | AGPL-3.0 |
-| 18 | 5.56 | Langchain-Chatchat | 0 | - | - | - | - | Apache-2.0 |
-| 19 | 5.55 | crewAI | 0 | - | - | - | - | MIT |
-| 20 | 5.51 | AgentGPT | 0 | - | - | - | - | GPL-3.0 |
-| 21 | 5.47 | agno | 0 | - | - | - | - | MPL-2.0 |
-| 22 | 5.46 | khoj | 0 | - | - | - | - | AGPL-3.0 |
-| 23 | 5.45 | ChatDev | 0 | - | - | - | - | Apache-2.0 |
-| 24 | 5.45 | LibreChat | 0 | - | - | - | - | MIT |
-| 25 | 5.43 | ai-agents-for-beginners | 0 | - | - | - | - | MIT |
-| 26 | 5.43 | cherry-studio | 0 | - | - | - | - | NOASSERTION |
-| 27 | 5.43 | Jobs_Applier_AI_Agent_AIHawk | 0 | - | - | - | - | AGPL-3.0 |
-| 28 | 5.42 | qlib | 0 | - | - | - | - | MIT |
-| 29 | 5.37 | composio | 0 | - | - | - | - | NOASSERTION |
-| 30 | 5.36 | FastGPT | 0 | - | - | - | - | NOASSERTION |
-| 31 | 5.35 | gpt-researcher | 0 | - | - | - | - | Apache-2.0 |
-| 32 | 5.33 | CopilotKit | 0 | - | - | - | - | MIT |
-| 33 | 5.33 | haystack | 0 | - | - | - | - | Apache-2.0 |
-| 34 | 5.26 | swarm | 0 | - | - | - | - | MIT |
-| 35 | 5.24 | agentic | 0 | - | - | - | - | MIT |
-| 36 | 5.23 | vanna | 0 | - | - | - | - | MIT |
-| 37 | 5.21 | DB-GPT | 0 | - | - | - | - | MIT |
-| 38 | 5.21 | deep-research | 0 | - | - | - | - | MIT |
-| 39 | 5.21 | letta | 0 | - | - | - | - | Apache-2.0 |
-| 40 | 5.20 | agenticSeek | 0 | - | - | - | - | GPL-3.0 |
-| 41 | 5.20 | SWE-agent | 0 | - | - | - | - | MIT |
-| 42 | 5.19 | eliza | 0 | - | - | - | - | MIT |
-| 43 | 5.19 | RagaAI-Catalyst | 0 | - | - | - | - | Apache-2.0 |
-| 44 | 5.18 | DocsGPT | 0 | - | - | - | - | MIT |
-| 45 | 5.17 | awesome-ai-agents | 0 | - | - | - | - | NOASSERTION |
-| 46 | 5.14 | devika | 0 | - | - | - | - | MIT |
-| 47 | 5.14 | goose | 0 | - | - | - | - | Apache-2.0 |
-| 48 | 5.13 | suna | 0 | - | - | - | - | Apache-2.0 |
-| 49 | 5.13 | SuperAGI | 0 | - | - | - | - | MIT |
-| 50 | 5.12 | ai-pdf-chatbot-langchain | 0 | - | - | - | - | MIT |
-| 51 | 5.12 | dagger | 0 | - | - | - | - | Apache-2.0 |
-| 52 | 5.11 | activepieces | 0 | - | - | - | - | NOASSERTION |
-| 53 | 5.11 | botpress | 0 | - | - | - | - | MIT |
-| 54 | 5.11 | plandex | 0 | - | - | - | - | MIT |
-| 55 | 5.11 | web-ui | 0 | - | - | - | - | MIT |
-| 56 | 5.10 | ai | 0 | - | - | - | - | NOASSERTION |
-| 57 | 5.10 | deer-flow | 0 | - | - | - | - | MIT |
-| 58 | 5.08 | camel | 0 | - | - | - | - | Apache-2.0 |
-| 59 | 5.08 | ChuanhuChatGPT | 0 | - | - | - | - | GPL-3.0 |
-| 60 | 5.08 | mastra | 0 | - | - | - | - | NOASSERTION |
-| 61 | 5.04 | GenAI_Agents | 0 | - | - | - | - | NOASSERTION |
-| 62 | 5.02 | Llama-Chinese | 0 | - | - | - | - | - |
-| 63 | 5.02 | openai-agents-python | 0 | - | - | - | - | MIT |
-| 64 | 5.01 | graphiti | 0 | - | - | - | - | Apache-2.0 |
-| 65 | 4.99 | LangBot | 0 | - | - | - | - | AGPL-3.0 |
-| 66 | 4.96 | pydantic-ai | 0 | - | - | - | - | MIT |
-| 67 | 4.95 | adk-python | 0 | - | - | - | - | Apache-2.0 |
-| 68 | 4.94 | ai-engineering-hub | 0 | - | - | - | - | MIT |
-| 69 | 4.93 | opik | 0 | - | - | - | - | Apache-2.0 |
-| 70 | 4.93 | Qwen-Agent | 0 | - | - | - | - | Apache-2.0 |
-| 71 | 4.89 | agent-zero | 0 | - | - | - | - | NOASSERTION |
-| 72 | 4.89 | bisheng | 0 | - | - | - | - | Apache-2.0 |
-| 73 | 4.88 | AstrBot | 0 | - | - | - | - | AGPL-3.0 |
-| 74 | 4.88 | E2B | 0 | - | - | - | - | Apache-2.0 |
-| 75 | 4.87 | cua | 0 | - | - | - | - | MIT |
-| 76 | 4.85 | Figma-Context-MCP | 0 | - | - | - | - | MIT |
-| 77 | 4.82 | Bert-VITS2 | 0 | - | - | - | - | AGPL-3.0 |
-| 78 | 4.81 | Upsonic | 0 | - | - | - | - | MIT |
-| 79 | 4.80 | agentscope | 0 | - | - | - | - | Apache-2.0 |
-| 80 | 4.80 | pr-agent | 0 | - | - | - | - | AGPL-3.0 |
-| 81 | 4.80 | UFO | 0 | - | - | - | - | MIT |
-| 82 | 4.79 | awesome-LLM-resources | 0 | - | - | - | - | Apache-2.0 |
-| 83 | 4.79 | WrenAI | 0 | - | - | - | - | AGPL-3.0 |
-| 84 | 4.78 | OpenRLHF | 0 | - | - | - | - | Apache-2.0 |
-| 85 | 4.78 | promptfoo | 0 | - | - | - | - | MIT |
-| 86 | 4.77 | aichat | 0 | - | - | - | - | Apache-2.0 |
-| 87 | 4.77 | R2R | 0 | - | - | - | - | MIT |
-| 88 | 4.75 | nanobrowser | 0 | - | - | - | - | Apache-2.0 |
-| 89 | 4.73 | intentkit | 0 | - | - | - | - | MIT |
-| 90 | 4.72 | agents | 0 | - | - | - | - | Apache-2.0 |
-| 91 | 4.71 | deep-searcher | 0 | - | - | - | - | Apache-2.0 |
-| 92 | 4.70 | XAgent | 0 | - | - | - | - | Apache-2.0 |
-| 93 | 4.69 | agent-squad | 0 | - | - | - | - | Apache-2.0 |
-| 94 | 4.68 | LLocalSearch | 0 | - | - | - | - | Apache-2.0 |
-| 95 | 4.68 | RD-Agent | 0 | - | - | - | - | MIT |
-| 96 | 4.67 | lamda | 0 | - | - | - | - | - |
-| 97 | 4.67 | TaskWeaver | 0 | - | - | - | - | MIT |
-| 98 | 4.66 | mcp-agent | 0 | - | - | - | - | Apache-2.0 |
-| 99 | 4.66 | superagent | 0 | - | - | - | - | MIT |
-| 100 | 4.66 | ten-framework | 0 | - | - | - | - | NOASSERTION |
+| Rank | Repo | Score | Stars | Δ Stars | Δ Score | Recency | Issue Health | Doc Complete | License Freedom | Ecosystem | log₂(Stars) | Category |
+|-----:|------|------:|------:|--------:|--------:|-------:|-------------:|-------------:|---------------:|---------:|------------:|----------|
+| 1 | dify | 6.07 | 103135 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 16.65 | General-purpose |
+| 2 | langflow | 5.96 | 73030 |  | +0 | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 16.16 | DevTools |
+| 3 | browser-use | 5.88 | 63085 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.95 | General-purpose |
+| 4 | OpenHands | 5.84 | 57980 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.82 | General-purpose |
+| 5 | lobe-chat | 5.83 | 62452 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 15.93 | RAG-centric |
+| 6 | MetaGPT | 5.82 | 56381 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.78 | Multi-Agent Coordination |
+| 7 | ragflow | 5.81 | 55032 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.75 | RAG-centric |
+| 8 | LLaMA-Factory | 5.79 | 52214 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.67 | General-purpose |
+| 9 | system-prompts-and-models... | 5.78 | 57188 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 15.80 | DevTools |
+| 10 | cline | 5.72 | 45640 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.48 | General-purpose |
+| 11 | anything-llm | 5.71 | 45276 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.47 | RAG-centric |
+| 12 | llama_index | 5.68 | 42328 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.37 | General-purpose |
+| 13 | autogen | 5.67 | 45934 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 15.49 | General-purpose |
+| 14 | awesome-llm-apps | 5.63 | 38434 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.23 | RAG-centric |
+| 15 | Flowise | 5.60 | 39990 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 15.29 | General-purpose |
+| 16 | mem0 | 5.57 | 34409 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.07 | General-purpose |
+| 17 | ChatTTS | 5.56 | 36777 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 15.17 | General-purpose |
+| 18 | Langchain-Chatchat | 5.56 | 35279 |  |  | 0.85 | 0.00 | 0.00 | 1.00 | 0.00 | 15.11 | RAG-centric |
+| 19 | crewAI | 5.55 | 32869 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 15.00 | Multi-Agent Coordination |
+| 20 | AgentGPT | 5.51 | 34319 |  |  | 0.95 | 0.00 | 0.00 | 0.50 | 0.00 | 15.07 | General-purpose |
+| 21 | agno | 5.47 | 28227 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.78 | Multi-Agent Coordination |
+| 22 | khoj | 5.46 | 30318 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.89 | Experimental |
+| 23 | ChatDev | 5.45 | 27021 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.72 | Multi-Agent Coordination |
+| 24 | LibreChat | 5.45 | 26727 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.71 | General-purpose |
+| 25 | ai-agents-for-beginners | 5.43 | 26018 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.67 | General-purpose |
+| 26 | cherry-studio | 5.43 | 28392 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.79 | General-purpose |
+| 27 | Jobs_Applier_AI_Agent_AIHawk | 5.43 | 28304 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.79 | General-purpose |
+| 28 | qlib | 5.42 | 25080 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.61 | Experimental |
+| 29 | composio | 5.37 | 25493 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.64 | General-purpose |
+| 30 | FastGPT | 5.36 | 24714 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.59 | RAG-centric |
+| 31 | gpt-researcher | 5.35 | 21855 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.42 | Experimental |
+| 32 | CopilotKit | 5.33 | 21149 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.37 | General-purpose |
+| 33 | haystack | 5.33 | 21141 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.37 | RAG-centric |
+| 34 | swarm | 5.26 | 19917 |  |  | 0.81 | 0.00 | 0.00 | 1.00 | 0.00 | 14.28 | Multi-Agent Coordination |
+| 35 | agentic | 5.24 | 17632 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.11 | General-purpose |
+| 36 | vanna | 5.23 | 18102 |  |  | 0.90 | 0.00 | 0.00 | 1.00 | 0.00 | 14.14 | RAG-centric |
+| 37 | DB-GPT | 5.21 | 16757 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.03 | General-purpose |
+| 38 | deep-research | 5.21 | 16627 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.02 | Experimental |
+| 39 | letta | 5.21 | 16841 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 14.04 | General-purpose |
+| 40 | agenticSeek | 5.20 | 18115 |  |  | 1.00 | 0.00 | 0.00 | 0.50 | 0.00 | 14.14 | General-purpose |
+| 41 | SWE-agent | 5.20 | 16282 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.99 | General-purpose |
+| 42 | eliza | 5.19 | 16065 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.97 | General-purpose |
+| 43 | RagaAI-Catalyst | 5.19 | 16188 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.98 | RAG-centric |
+| 44 | DocsGPT | 5.18 | 15708 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.94 | DevTools |
+| 45 | awesome-ai-agents | 5.17 | 18563 |  |  | 0.77 | 0.00 | 0.00 | 0.50 | 0.00 | 14.18 | General-purpose |
+| 46 | devika | 5.14 | 19330 |  |  | 0.29 | 0.00 | 0.00 | 1.00 | 0.00 | 14.24 | Experimental |
+| 47 | goose | 5.14 | 14558 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.83 | General-purpose |
+| 48 | suna | 5.13 | 14367 |  |  | 1.00 | 0.00 | 0.00 | 1.00 | 0.00 | 13.81 | General-purpose |
+| 49 | SuperAGI | 5.13 | 16412 |  |  | 0.67 | 0.00 | 0.00 | 1.00 | 0.00 | 14.00 | RAG-centric |
+| 50 | ai-pdf-chatbot-langchain | 5.12 | 15572 |  |  | 0.75 | 0.00 | 0.00 | 1.00 | 0.00 | 13.93 | General-purpose |
 <!-- TOP50:END -->
 *➡️ Dig into how these scores are cooked up in our [Methodology section](#our-methodology--scoring-explained) and the [full recipe in /docs/methodology.md](./docs/methodology.md).*
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -23,6 +23,16 @@ def _canonical(name: str) -> str:
         "fit": "fit",
         "license": "license",
         "rank": "rank",
+        "recency": "recency",
+        "issue health": "issue_health",
+        "doc complete": "docs",
+        "license freedom": "license_freedom",
+        "ecosystem": "ecosystem",
+        "log2stars": "log2stars",
+        "log₂stars": "log2stars",
+        "category": "category",
+        "delta stars": "stars_delta",
+        "delta score": "score_delta",
     }
     return mapping.get(name, name)
 

--- a/tests/test_inject_cli_script.py
+++ b/tests/test_inject_cli_script.py
@@ -6,12 +6,19 @@ from pathlib import Path
 def test_inject_script_check(monkeypatch, tmp_path):
     calls = {}
 
-    def fake_main(force=False, check=False, write=True, sort_by="overall", top_n=100):
-        calls["args"] = (force, check, write, sort_by, top_n)
+    def fake_main(
+        force=False,
+        check=False,
+        write=True,
+        sort_by="score",
+        top_n=100,
+        limit=None,
+    ):
+        calls["args"] = (force, check, write, sort_by, top_n, limit)
         return 0
 
     monkeypatch.setattr("agentic_index_cli.internal.inject_readme.main", fake_main)
     script = Path(__file__).resolve().parents[1] / "scripts" / "inject_readme.py"
     sys.argv = [str(script), "--check"]
     runpy.run_path(script, run_name="__main__")
-    assert calls["args"] == (False, True, False, "overall", 100)
+    assert calls["args"] == (False, True, False, "score", 100, None)

--- a/tests/test_inject_dry_run.py
+++ b/tests/test_inject_dry_run.py
@@ -22,8 +22,6 @@ def _setup(tmp_path, monkeypatch, readme_fixture_path, data_fixture_dir):
     data_dir.mkdir()
     shutil.copy(data_fixture_dir / "top100.md", data_dir / "top100.md")
     data = json.loads((data_fixture_dir / "repos.json").read_text())
-    for repo in data.get("repos", []):
-        repo.setdefault("stars_7d", 0)
     (data_dir / "repos.json").write_text(json.dumps(data))
     try:
         shutil.copy(
@@ -40,7 +38,7 @@ def _setup(tmp_path, monkeypatch, readme_fixture_path, data_fixture_dir):
     monkeypatch.setattr(inj, "REPOS_PATH", data_dir / "repos.json")
     monkeypatch.setattr(inj, "SNAPSHOT", data_dir / "last_snapshot.json")
 
-    modified = inj.build_readme(top_n=50, limit=100).strip()
+    modified = inj.build_readme(top_n=50, limit=50).strip()
     return readme, modified
 
 
@@ -62,7 +60,7 @@ def _bump_score(text: str, delta: float) -> str:
     for i, line in enumerate(lines):
         if line.startswith("| 1 |"):
             cells = [c.strip() for c in line.strip().strip("|").split("|")]
-            cells[1] = f"{float(cells[1]) + delta:.2f}"
+            cells[2] = f"{float(cells[2]) + delta:.2f}"
             lines[i] = "| " + " | ".join(cells) + " |"
             break
     return "\n".join(lines)
@@ -84,7 +82,7 @@ def _change_cell(text: str, col: int, value: str) -> str:
     [
         (lambda txt: _bump_score(txt, 0.015), True),
         (lambda txt: _bump_score(txt, 0.05), False),
-        (lambda txt: _change_cell(txt, 8, "MIT"), False),
+        (lambda txt: _change_cell(txt, 12, "MIT"), False),
         (lambda txt: _change_cell(txt, 0, "2"), False),
     ],
 )

--- a/tests/test_inject_markers.py
+++ b/tests/test_inject_markers.py
@@ -10,7 +10,7 @@ def test_missing_markers(tmp_path, monkeypatch):
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     (data_dir / "top100.md").write_text(
-        '| Rank | <abbr title="Overall">📊</abbr> Overall | Repo | <abbr title="Stars gained in last 7 days">⭐ Δ7d</abbr> | <abbr title="Maintenance score">🔧 Maint</abbr> | <abbr title="Last release date">📅 Release</abbr> | <abbr title="Documentation score">📚 Docs</abbr> | <abbr title="Ecosystem fit">🧠 Fit</abbr> | <abbr title="License">⚖️ License</abbr> |\n|-----:|------:|------|-------:|-------:|-----------|-------:|-------:|---------|\n'
+        "| Rank | Repo | Score | Stars | Δ Stars | Δ Score | Recency | Issue Health | Doc Complete | License Freedom | Ecosystem | log₂(Stars) | Category |\n|-----:|------|------:|------:|--------:|--------:|-------:|-------------:|-------------:|---------------:|---------:|------------:|----------|\n"
     )
     readme.write_text("no table here")
 

--- a/tests/test_inject_readme_unit.py
+++ b/tests/test_inject_readme_unit.py
@@ -12,26 +12,29 @@ def _setup(tmp_path: Path, top_n: int = 50) -> Path:
     (data_dir / "repos.json").write_text(
         json.dumps(
             {
-                "schema_version": 2,
+                "schema_version": 3,
                 "repos": [
                     {
                         "name": "x",
                         "full_name": "o/x",
                         "AgenticIndexScore": 1.0,
-                        "stars_7d": 1,
-                        "maintenance": 0.5,
-                        "docs_score": 0.5,
-                        "ecosystem": 0.3,
-                        "last_release": None,
-                        "license": "MIT",
+                        "stars": 10,
+                        "stars_delta": 1,
                         "score_delta": 0,
+                        "recency_factor": 1.0,
+                        "issue_health": 0.5,
+                        "doc_completeness": 0.5,
+                        "license_freedom": 0.9,
+                        "ecosystem_integration": 0.3,
+                        "stars_log2": 3.32,
+                        "category": "General",
                     }
                 ],
             }
         )
     )
     (data_dir / "top100.md").write_text(
-        '| Rank | <abbr title="Overall">📊</abbr> Overall | Repo | <abbr title="Stars gained in last 7 days">⭐ Δ7d</abbr> | <abbr title="Maintenance score">🔧 Maint</abbr> | <abbr title="Last release date">📅 Release</abbr> | <abbr title="Documentation score">📚 Docs</abbr> | <abbr title="Ecosystem fit">🧠 Fit</abbr> | <abbr title="License">⚖️ License</abbr> |\n|-----:|------:|------|-------:|-------:|-----------|-------:|-------:|---------|\n| 1 | 1.00 | x | 1 | 0.50 | - | 0.50 | 0.30 | MIT |\n'
+        "| Rank | Repo | Score | Stars | Δ Stars | Δ Score | Recency | Issue Health | Doc Complete | License Freedom | Ecosystem | log₂(Stars) | Category |\n|-----:|------|------:|------:|--------:|--------:|-------:|-------------:|-------------:|---------------:|---------:|------------:|----------|\n| 1 | x | 1.00 | 10 | +1 |  | 1.00 | 0.50 | 0.50 | 0.90 | 0.30 | 3.32 | General |\n"
     )
     (data_dir / "last_snapshot.json").write_text("[]")
     readme = tmp_path / "README.md"
@@ -54,7 +57,7 @@ def test_inject_and_check(tmp_path, monkeypatch):
 
     assert inj.main(top_n=50) == 0
     text = readme.read_text()
-    assert "| 1 | 1.00 | x |" in text
+    assert "| 1 | x | 1.00 |" in text
 
     assert inj.main(check=True, top_n=50) == 0
 
@@ -67,7 +70,8 @@ def test_check_fails_when_outdated(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "field", ["name", "full_name", "AgenticIndexScore", "score_delta"]
+    "field",
+    ["name", "full_name", "AgenticIndexScore", "stars"],
 )
 def test_missing_required_key(tmp_path, monkeypatch, field):
     _setup(tmp_path)

--- a/tests/test_inject_row_count.py
+++ b/tests/test_inject_row_count.py
@@ -14,17 +14,20 @@ def _prepare(tmp_path: Path, top_n: int, repo_count: int) -> Path:
                 "name": f"r{i}",
                 "full_name": f"o/r{i}",
                 "AgenticIndexScore": 1.0 + i,
-                "stars_7d": i,
-                "maintenance": 0.5,
-                "docs_score": 0.5,
-                "ecosystem": 0.3,
-                "last_release": None,
-                "license": "MIT",
+                "stars": i,
+                "stars_delta": i,
                 "score_delta": 0,
+                "recency_factor": 1.0,
+                "issue_health": 1.0,
+                "doc_completeness": 0.5,
+                "license_freedom": 1.0,
+                "ecosystem_integration": 0.3,
+                "stars_log2": 1.0 + i,
+                "category": "c",
             }
         )
     (data_dir / "repos.json").write_text(
-        json.dumps({"schema_version": 2, "repos": repos})
+        json.dumps({"schema_version": 3, "repos": repos})
     )
     (data_dir / "last_snapshot.json").write_text("[]")
     readme = tmp_path / "README.md"

--- a/tests/test_inject_script.py
+++ b/tests/test_inject_script.py
@@ -7,10 +7,10 @@ def test_inject_readme(tmp_path, monkeypatch):
     readme = tmp_path / "README.md"
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    table = '| Rank | <abbr title="Overall">📊</abbr> Overall | Repo | <abbr title="Stars gained in last 7 days">⭐ Δ7d</abbr> | <abbr title="Maintenance score">🔧 Maint</abbr> | <abbr title="Last release date">📅 Release</abbr> | <abbr title="Documentation score">📚 Docs</abbr> | <abbr title="Ecosystem fit">🧠 Fit</abbr> | <abbr title="License">⚖️ License</abbr> |\n|-----:|------:|------|-------:|-------:|-----------|-------:|-------:|---------|\n| 1 | 1.00 | x | 1 | 0.50 | - | 0.50 | 0.30 | MIT |\n'
+    table = "| Rank | Repo | Score | Stars | Δ Stars | Δ Score | Recency | Issue Health | Doc Complete | License Freedom | Ecosystem | log₂(Stars) | Category |\n|-----:|------|------:|------:|--------:|--------:|-------:|-------------:|-------------:|---------------:|---------:|------------:|----------|\n| 1 | x | 1.00 | 10 | +1 |  | 1.00 | 0.50 | 0.50 | 0.90 | 0.30 | 3.32 | Test |\n"
     (data_dir / "top100.md").write_text(table)
     (data_dir / "repos.json").write_text(
-        '{"schema_version":2,"repos":[{"name":"x","full_name":"o/x","AgenticIndexScore":1.0,"stars_7d":1,"maintenance":0.5,"docs_score":0.5,"ecosystem":0.3,"last_release":null,"license":"MIT","score_delta":0}]}'
+        '{"schema_version":3,"repos":[{"name":"x","full_name":"o/x","AgenticIndexScore":1.0,"stars":10,"stars_delta":1,"score_delta":0,"recency_factor":1.0,"issue_health":0.5,"doc_completeness":0.5,"license_freedom":0.9,"ecosystem_integration":0.3,"stars_log2":3.32,"category":"Test"}]}'
     )
 
     monkeypatch.setattr(inj, "REPOS_PATH", data_dir / "repos.json")
@@ -23,5 +23,5 @@ def test_inject_readme(tmp_path, monkeypatch):
 
     assert inj.main(top_n=50) == 0
     content = readme.read_text()
-    assert "| 1 | 1.00 | x |" in content
+    assert "| 1 | x | 1.00 |" in content
     assert content.count("<!-- TOP50:START -->") == 1

--- a/tests/test_no_zero_metrics.py
+++ b/tests/test_no_zero_metrics.py
@@ -14,24 +14,35 @@ def _setup(tmp_path: Path):
             "name": "a",
             "full_name": "o/a",
             "AgenticIndexScore": 1.0,
-            "stars_7d": 0,
-            "license": "MIT",
+            "stars": 0,
+            "stars_delta": 0,
             "score_delta": 0,
+            "recency_factor": 0.0,
+            "issue_health": 0.0,
+            "doc_completeness": 0.0,
+            "license_freedom": 0.0,
+            "ecosystem_integration": 0.0,
+            "stars_log2": 0.0,
+            "category": "Test",
         },
         {
             "name": "b",
             "full_name": "o/b",
             "AgenticIndexScore": 2.0,
-            "stars_7d": 0,
-            "maintenance": 0.5,
-            "docs_score": 0.5,
-            "ecosystem": 0.2,
-            "license": "MIT",
+            "stars": 0,
+            "stars_delta": 0,
             "score_delta": 0,
+            "recency_factor": 0.5,
+            "issue_health": 0.6,
+            "doc_completeness": 0.0,
+            "license_freedom": 0.0,
+            "ecosystem_integration": 0.2,
+            "stars_log2": 0.0,
+            "category": "Test",
         },
     ]
     (data_dir / "repos.json").write_text(
-        json.dumps({"schema_version": 2, "repos": repos})
+        json.dumps({"schema_version": 3, "repos": repos})
     )
     (data_dir / "top100.md").write_text("")
     (data_dir / "last_snapshot.json").write_text("[]")
@@ -53,6 +64,12 @@ def test_no_all_zero_rows(tmp_path):
     lines = [l for l in text.splitlines() if l.startswith("|")][2:]
     for line in lines:
         parts = [p.strip() for p in line.split("|")]
-        maint, docs, eco = parts[5], parts[7], parts[8]
-        if maint == docs == eco == "0.00":
+        rec, health, docs, lic, eco = (
+            parts[6],
+            parts[7],
+            parts[8],
+            parts[9],
+            parts[10],
+        )
+        if rec == health == docs == lic == eco == "0.00":
             raise AssertionError("row shows all zero metrics")

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -74,6 +74,13 @@ def test_end_to_end(tmp_path, monkeypatch, min_stars):
     assert data_file.exists()
     assert (tmp_path / "data/history").exists()
 
+    # enrich with derived metrics required for injection
+    enrich_path = Path("agentic_index_cli/enricher.py")
+    import importlib
+
+    enricher = importlib.import_module("agentic_index_cli.enricher")
+    enricher.enrich(data_file)
+
     scorer.main(str(data_file))
 
     env = os.environ.copy()

--- a/tests/test_snapshot_presence.py
+++ b/tests/test_snapshot_presence.py
@@ -12,8 +12,6 @@ def test_injector_handles_missing_snapshot(tmp_path, capsys, monkeypatch):
     data_dir.mkdir()
     shutil.copy(ROOT / "data" / "top100.md", data_dir / "top100.md")
     data = json.loads((ROOT / "data" / "repos.json").read_text())
-    for repo in data.get("repos", []):
-        repo.setdefault("stars_7d", 0)
     (data_dir / "repos.json").write_text(json.dumps(data))
     # intentionally do not provide last_snapshot.json
 

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -14,29 +14,35 @@ def _setup(tmp_path: Path):
             "name": "A",
             "full_name": "o/A",
             "AgenticIndexScore": 1.0,
-            "stars_7d": 10,
-            "maintenance": 0.5,
-            "docs_score": 0.0,
-            "ecosystem": 0.0,
-            "last_release": "2025-06-01T00:00:00Z",
-            "license": "MIT",
-            "score_delta": 0,
+            "stars": 10,
+            "stars_delta": 5,
+            "score_delta": 0.1,
+            "recency_factor": 0.5,
+            "issue_health": 0.8,
+            "doc_completeness": 0.0,
+            "license_freedom": 1.0,
+            "ecosystem_integration": 0.0,
+            "stars_log2": 3.32,
+            "category": "A",
         },
         {
             "name": "B",
             "full_name": "o/B",
             "AgenticIndexScore": 2.0,
-            "stars_7d": 5,
-            "maintenance": 0.9,
-            "docs_score": 0.0,
-            "ecosystem": 0.0,
-            "last_release": "2025-05-01T00:00:00Z",
-            "license": "MIT",
-            "score_delta": 0,
+            "stars": 5,
+            "stars_delta": 1,
+            "score_delta": 0.2,
+            "recency_factor": 0.9,
+            "issue_health": 0.7,
+            "doc_completeness": 0.0,
+            "license_freedom": 1.0,
+            "ecosystem_integration": 0.0,
+            "stars_log2": 2.32,
+            "category": "B",
         },
     ]
     (data_dir / "repos.json").write_text(
-        json.dumps({"schema_version": 2, "repos": repos})
+        json.dumps({"schema_version": 3, "repos": repos})
     )
     (data_dir / "top100.md").write_text("")
     (data_dir / "last_snapshot.json").write_text("[]")
@@ -56,21 +62,20 @@ def _setup(tmp_path: Path):
 @pytest.mark.parametrize(
     "field,first",
     [
-        ("overall", "B"),
-        ("stars_7d", "A"),
-        ("maintenance", "B"),
-        ("last_release", "A"),
+        ("score", "B"),
+        ("stars", "A"),
+        ("recency", "B"),
     ],
 )
 def test_sort_order(tmp_path, field, first):
     _setup(tmp_path)
     text = inj.build_readme(sort_by=field, top_n=50)
     lines = [l for l in text.splitlines() if l.startswith("|")][2:]
-    assert lines[0].split("|")[3].strip() == first
+    assert lines[0].split("|")[2].strip() == first
 
 
 def test_stable_between_runs(tmp_path):
     _setup(tmp_path)
-    first = inj.build_readme(sort_by="stars_7d", top_n=50)
-    second = inj.build_readme(sort_by="stars_7d", top_n=50)
+    first = inj.build_readme(sort_by="stars", top_n=50)
+    second = inj.build_readme(sort_by="stars", top_n=50)
     assert first == second

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -14,16 +14,16 @@ def test_readme_synced():
     lines = [l for l in text[start:end].splitlines() if l.startswith("|")]
     for line in lines[2:]:
         cells = [c.strip() for c in line.strip().strip("|").split("|")]
-        assert len(cells) >= 9
+        assert len(cells) >= 13
         int(cells[0])
-        float(cells[1])
+        float(cells[2])
         int(cells[3])
-        if cells[4] != "-":
-            float(cells[4])
+        if cells[4] and cells[4] != "+new":
+            int(cells[4].replace("+", ""))
+        if cells[5] and cells[5] != "+new":
+            float(cells[5].replace("+", ""))
         if cells[6] != "-":
             float(cells[6])
-        if cells[7] != "-":
-            float(cells[7])
 
 
 def test_inject_idempotent(tmp_path):


### PR DESCRIPTION
Closes #106

## Summary
- update injection logic to render schema v3 metrics
- add CLI `--limit` option and new sort fields
- refresh README fixture and tests for new header
- adjust helper utilities and parsing logic
- update pipeline and sync tests

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685054ed3b3c832ab571b1e062445586