### PR TITLE
Suppress pip root warning

### DIFF
--- a/scripts/agent-setup.sh
+++ b/scripts/agent-setup.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Silence pip's warning about running as root
+export PIP_ROOT_USER_ACTION=ignore
+
 # Install project dependencies
 pip install -r requirements.txt
 pip install -e .


### PR DESCRIPTION
## Summary
- suppress pip root user warning in `agent-setup.sh`

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68505f91dbac832a9ccce6c0c16139e4