### PR TITLE
Add environment setup automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,10 @@
   ```
 
 ## Setup
-- Use `scripts/agent-setup.sh` to install all dependencies and pre-commit hooks:
+- Source `scripts/setup-env.sh` to validate your Python version, install system
+  packages, and configure a virtual environment:
   ```bash
-  bash scripts/agent-setup.sh
+  source scripts/setup-env.sh
   ```
 
 ## PR Guidelines

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Check out [CONTRIBUTING.md](./CONTRIBUTING.md) for how to:
   * Install [Git LFS](https://git-lfs.github.com/) and run `git lfs install`.
     PNG and GIF assets are tracked via LFS.
   * Set up your dev environment with [DEVELOPMENT.md](./docs/DEVELOPMENT.md).
-  * Install dependencies with `scripts/agent-setup.sh` (includes formatting tools).
+  * Run `source scripts/setup-env.sh` to configure your environment.
 
 For tips on keeping your branch in sync with `main` and resolving conflicts, see
 [CONFLICT_RESOLUTION.md](./docs/CONFLICT_RESOLUTION.md).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -15,21 +15,18 @@ graph TD
     G --> H(Push and open PR)
 ```
 
-## Common commands
+## Quick setup
+
+Run the helper script to prepare your environment:
 
 ```bash
-# install runtime deps
-pip install -r requirements.txt
-
-# install the package in editable mode
-pip install -e .
-
-# set up hooks and run lint/tests automatically
-pre-commit install
-
-# run the full test suite
-pytest -q
+source scripts/setup-env.sh
 ```
+
+The script verifies Python ≥3.10, installs required system packages, creates a
+virtual environment with all dependencies, exports `PYTHONPATH`, and installs
+pre-commit hooks. It also loads any variables in a `.env` file or prompts for
+missing values such as API keys.
 
 ## Troubleshooting FAQ
 

--- a/docs/test-issue-logger.md
+++ b/docs/test-issue-logger.md
@@ -2,8 +2,7 @@
 
 This document describes manual testing of the `issue_logger.py` CLI tool.
 
-## Environment
-- dependencies installed via `scripts/agent-setup.sh`
+- dependencies installed via `scripts/setup-env.sh`
 - no valid `GITHUB_TOKEN` available
 
 ## Observed Behavior

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure the script is sourced so exports persist
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "Please source this script: source scripts/setup-env.sh"
+  exit 1
+fi
+
+PY_VER=$(python3 -c 'import sys; print("{}.{}.{}".format(*sys.version_info[:3]))')
+if ! python3 - <<'PY'
+import sys
+raise SystemExit(0 if sys.version_info >= (3,10) else 1)
+PY
+then
+  echo "Python 3.10 or newer required. Found $PY_VER"
+  return 1
+fi
+
+MISSING=()
+for pkg in libffi-dev libssl-dev; do
+  if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+    MISSING+=("$pkg")
+  fi
+done
+if (( ${#MISSING[@]} )); then
+  echo "Installing system packages: ${MISSING[*]}"
+  sudo apt-get update
+  sudo apt-get install -y "${MISSING[@]}"
+fi
+
+if [[ ! -d .venv ]]; then
+  python3 -m venv .venv
+fi
+source .venv/bin/activate
+
+pip install --upgrade pip
+pip install -r requirements.txt
+pip install -e .
+pip install black isort flake8 mypy bandit pre-commit
+pre-commit install --install-hooks
+
+export PYTHONPATH="$PWD"
+
+if [[ -f .env ]]; then
+  echo "Loading environment variables from .env"
+  set -o allexport
+  source .env
+  set +o allexport
+else
+  REQUIRED_VARS=(GITHUB_TOKEN_REPO_STATS API_KEY)
+  for var in "${REQUIRED_VARS[@]}"; do
+    if [[ -z "${!var:-}" ]]; then
+      read -rp "Enter value for $var: " val
+      export "$var"="$val"
+    fi
+  done
+fi
+
+python - <<'PY'
+import sys
+try:
+    import agentic_index_cli
+except Exception as e:
+    sys.exit(f"Sanity check failed: {e}")
+PY
+
+echo "Environment setup complete."

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -308,7 +308,7 @@ Check out [CONTRIBUTING.md](./CONTRIBUTING.md) for how to:
   * Install [Git LFS](https://git-lfs.github.com/) and run `git lfs install`.
     PNG and GIF assets are tracked via LFS.
   * Set up your dev environment with [DEVELOPMENT.md](./docs/DEVELOPMENT.md).
-  * Install dependencies with `scripts/agent-setup.sh` (includes formatting tools).
+  * Run `source scripts/setup-env.sh` to configure your environment.
 
 For tips on keeping your branch in sync with `main` and resolving conflicts, see
 [CONFLICT_RESOLUTION.md](./docs/CONFLICT_RESOLUTION.md).


### PR DESCRIPTION
## Summary
- add `scripts/setup-env.sh` to automate local environment setup
- update onboarding docs to reference the new script
- refresh README and snapshot with setup instructions

Closes #108

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q` *(fails: 48 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6850621c9bac832abeb10a967338097d