### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,10 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# Provide setup script inside the image for post-create hook
+COPY scripts/setup-env.sh /usr/local/bin/setup-env.sh
+RUN chmod +x /usr/local/bin/setup-env.sh
+
 # Install Python tooling
 # Use explicit index to avoid firewall blocks
 RUN pip install --no-cache-dir \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,19 @@
 {
     "name": "Agentic Index Dev Container",
-    "build": {
-        "dockerfile": "Dockerfile"
-    },
-    "postCreateCommand": "pre-commit install",
+    "build": {"dockerfile": "Dockerfile"},
+    "postCreateCommand": "/usr/local/bin/setup-env.sh",
+    "forwardPorts": [8000],
     "customizations": {
         "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-pytest.pytest",
+                "redhat.vscode-yaml",
+            ],
             "workspaceCommands": [
-                { "name": "Run Tests", "command": "pytest -q" },
-                { "name": "Run Scrape", "command": "python scripts/scrape.py" }
-            ]
+                {"name": "Run Tests", "command": "pytest -q"},
+                {"name": "Run Scrape", "command": "python scripts/scrape.py"},
+            ],
         }
-    }
+    },
 }

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,17 @@
+name: DevContainer Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build dev container
+        uses: devcontainers/ci@v0.3
+        with:
+          push: never
+          runCmd: "python --version"

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,14 @@
+# Onboarding
+
+Use the provided dev container to get a consistent development setup.
+
+## GitHub Codespaces
+1. Open the repository on GitHub and click **Code**.
+2. Select the **Codespaces** tab and create a new codespace.
+3. The container builds automatically and runs `scripts/setup-env.sh` on first launch.
+
+## VS Code Remote – Containers
+1. Install the *Dev Containers* extension for VS Code.
+2. Clone this repository locally and open it in VS Code.
+3. Press `F1` and run **Dev Containers: Reopen in Container**.
+4. The environment builds and forwards port 8000 for the API server.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,3 +4,6 @@ Welcome to the Agentic Index documentation site. Here you'll find an overview of
 
 For a high-level view of module relationships, see the dependency diagrams in
 [`docs/architecture`](architecture/README.md).
+
+New contributors should start with the [ONBOARDING guide](ONBOARDING.md) which
+explains how to launch the dev container via Codespaces or VS Code.

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper script for devcontainer initialization
+bash "$(dirname "$0")/agent-setup.sh"


### PR DESCRIPTION
## Summary
- add setup-env script for container initialization
- install that script in Dockerfile
- run setup script after container creation and forward port 8000
- list required VS Code extensions
- add onboarding docs and link from docs index
- validate dev container build in CI

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506247d494832abece5ba1219b873c