### PR TITLE
Add by-category repo lists

### DIFF
--- a/agentic_index_cli/internal/rank.py
+++ b/agentic_index_cli/internal/rank.py
@@ -198,6 +198,18 @@ def main(json_path: str = "data/repos.json", *, config: dict | None = None) -> N
         for old in snapshots[:-delta_days]:
             old.unlink()
 
+        # write per-category lists
+        by_cat = data_dir / "by_category"
+        by_cat.mkdir(exist_ok=True)
+        index: dict[str, str] = {}
+        for cat in sorted({r.get("category") for r in repos if r.get("category")}):
+            cat_repos = [r for r in repos if r.get("category") == cat]
+            cat_repos.sort(key=lambda r: r[SCORE_KEY], reverse=True)
+            fname = f"{cat}.json"
+            save_repos(by_cat / fname, cat_repos)
+            index[cat] = fname
+        (by_cat / "index.json").write_text(json.dumps(index, indent=2) + "\n")
+
     # top-50 table
     header = [
         "| Rank | Repo | Score | ▲ StarsΔ | ▲ ScoreΔ | Category |",

--- a/agentic_index_cli/validate.py
+++ b/agentic_index_cli/validate.py
@@ -39,6 +39,7 @@ class Repo(BaseModel):
     language: str | None = None
     pushed_at: str | None = None
     owner: Owner | None = None
+    topics: list[str] | None = None
     AgenticIndexScore: float | None = None
     category: str | None = None
     stars: int | None = None

--- a/schemas/repo.schema.json
+++ b/schemas/repo.schema.json
@@ -48,6 +48,10 @@
       "required": ["login"],
       "additionalProperties": true
     },
+    "topics": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
     "stars": {"type": "integer", "minimum": 0},
     "stars_delta": {"type": "integer"},
     "score_delta": {"type": "number"},

--- a/scripts/scrape_repos.py
+++ b/scripts/scrape_repos.py
@@ -150,6 +150,7 @@ def fetch_repo(full_name: str) -> Dict[str, Any]:
         "language": repo.get("language"),
         "pushed_at": repo.get("pushed_at"),
         "owner": {"login": repo.get("owner", {}).get("login")},
+        "topics": topics,
         "stars_7d": _compute_stars_delta(full_name, stars),
         "maintenance": 1.0,
         "docs_score": 0.0,

--- a/tests/test_by_category.py
+++ b/tests/test_by_category.py
@@ -1,0 +1,49 @@
+import json
+import os
+from pathlib import Path
+
+import agentic_index_cli.internal.rank as rank_mod
+
+
+def test_by_category_generation(tmp_path, monkeypatch):
+    repos = [
+        {
+            "name": "a",
+            "full_name": "o/a",
+            "stargazers_count": 10,
+            "forks_count": 0,
+            "open_issues_count": 0,
+            "pushed_at": "2025-01-01T00:00:00Z",
+            "owner": {"login": "o"},
+            "AgenticIndexScore": 1.0,
+            "category": "Cat1",
+            "topics": ["x"],
+        },
+        {
+            "name": "b",
+            "full_name": "o/b",
+            "stargazers_count": 5,
+            "forks_count": 0,
+            "open_issues_count": 0,
+            "pushed_at": "2025-01-02T00:00:00Z",
+            "owner": {"login": "o"},
+            "AgenticIndexScore": 2.0,
+            "category": "Cat2",
+            "topics": ["y"],
+        },
+    ]
+    data = {"schema_version": 3, "repos": repos}
+    data_path = tmp_path / "repos.json"
+    data_path.write_text(json.dumps(data))
+
+    monkeypatch.setattr(rank_mod, "infer_category", lambda repo: repo["category"])
+    os.environ["PYTEST_CURRENT_TEST"] = "1"
+    rank_mod.main(str(data_path))
+
+    out_dir = tmp_path / "by_category"
+    index = json.loads((out_dir / "index.json").read_text())
+    assert set(index.keys()) == {"Cat1", "Cat2"}
+
+    c1 = json.loads((out_dir / index["Cat1"]).read_text())
+    assert c1["repos"][0]["topics"] == ["x"]
+    assert c1["repos"][0]["category"] == "Cat1"


### PR DESCRIPTION
## Summary
- scrape topics from GitHub
- allow `topics` in repo schema and validation model
- write per-category ranked lists during ranking
- test by-category output generation

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850629d4b10832aabbfaa6908e2482d