### PR TITLE
CR-AI-105B: README category tables

### DIFF
--- a/scripts/inject_readme.py
+++ b/scripts/inject_readme.py
@@ -9,6 +9,8 @@ from agentic_index_cli.internal.inject_readme import (
     DEFAULT_SORT_FIELD,
     DEFAULT_TOP_N,
     main,
+    write_all_categories,
+    write_category_readme,
 )
 
 if __name__ == "__main__":
@@ -44,15 +46,43 @@ if __name__ == "__main__":
     )
     parser.add_argument("--top-n", type=int, default=DEFAULT_TOP_N)
     parser.add_argument("--limit", type=int, help="Maximum rows to render")
+    cat_group = parser.add_mutually_exclusive_group()
+    cat_group.add_argument("--category", help="Generate README for one category")
+    cat_group.add_argument(
+        "--all-categories",
+        action="store_true",
+        help="Generate README_<cat>.md for all categories",
+    )
     args = parser.parse_args()
 
     check = args.check or args.dry_run
     write = args.write or not check
-    main(
-        force=args.force,
-        check=check,
-        write=write,
-        sort_by=args.sort_by,
-        top_n=args.top_n,
-        limit=args.limit,
-    )
+    if args.category or args.all_categories:
+        if args.all_categories:
+            write_all_categories(
+                force=args.force,
+                check=check,
+                write=write,
+                sort_by=args.sort_by,
+                top_n=args.top_n,
+                limit=args.limit,
+            )
+        else:
+            write_category_readme(
+                args.category,
+                force=args.force,
+                check=check,
+                write=write,
+                sort_by=args.sort_by,
+                top_n=args.top_n,
+                limit=args.limit,
+            )
+    else:
+        main(
+            force=args.force,
+            check=check,
+            write=write,
+            sort_by=args.sort_by,
+            top_n=args.top_n,
+            limit=args.limit,
+        )

--- a/tests/test_category_readme.py
+++ b/tests/test_category_readme.py
@@ -1,0 +1,75 @@
+import json
+from pathlib import Path
+
+import agentic_index_cli.internal.inject_readme as inj
+
+
+def _setup(tmp_path: Path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    repos = [
+        {
+            "name": "a",
+            "full_name": "o/a",
+            "AgenticIndexScore": 1.0,
+            "stars": 10,
+            "stars_delta": 1,
+            "score_delta": 0,
+            "recency_factor": 1.0,
+            "issue_health": 0.5,
+            "doc_completeness": 0.5,
+            "license_freedom": 0.9,
+            "ecosystem_integration": 0.3,
+            "stars_log2": 3.32,
+            "category": "CatA",
+            "topics": ["ai-agent", "autonomous"],
+        },
+        {
+            "name": "b",
+            "full_name": "o/b",
+            "AgenticIndexScore": 2.0,
+            "stars": 5,
+            "stars_delta": 0,
+            "score_delta": 0,
+            "recency_factor": 1.0,
+            "issue_health": 0.5,
+            "doc_completeness": 0.5,
+            "license_freedom": 0.9,
+            "ecosystem_integration": 0.3,
+            "stars_log2": 2.32,
+            "category": "CatB",
+            "topics": ["llm"],
+        },
+    ]
+    (data_dir / "repos.json").write_text(
+        json.dumps({"schema_version": 3, "repos": repos})
+    )
+    (data_dir / "top100.md").write_text("")
+    (data_dir / "last_snapshot.json").write_text("[]")
+    for name, val in {
+        "ROOT": tmp_path,
+        "README_PATH": tmp_path / "README.md",
+        "DATA_PATH": data_dir / "top100.md",
+        "REPOS_PATH": data_dir / "repos.json",
+        "SNAPSHOT": data_dir / "last_snapshot.json",
+    }.items():
+        setattr(inj, name, val)
+    return tmp_path
+
+
+def test_write_category_readme(tmp_path):
+    _setup(tmp_path)
+    ret = inj.write_category_readme("CatA", force=True)
+    assert ret == 0
+    text = (tmp_path / "README_CatA.md").read_text()
+    assert "Top Agentic-AI Repositories: CatA" in text
+    assert "`ai-agent`" in text
+    assert "| 1 | a |" in text
+
+
+def test_write_all_categories(tmp_path):
+    _setup(tmp_path)
+    ret = inj.write_all_categories(force=True)
+    assert ret == 0
+    assert (tmp_path / "README_CatA.md").exists()
+    assert (tmp_path / "README_CatB.md").exists()

--- a/tests/test_inject_cli_script.py
+++ b/tests/test_inject_cli_script.py
@@ -22,3 +22,36 @@ def test_inject_script_check(monkeypatch, tmp_path):
     sys.argv = [str(script), "--check"]
     runpy.run_path(script, run_name="__main__")
     assert calls["args"] == (False, True, False, "score", 100, None)
+
+
+def test_inject_script_category(monkeypatch):
+    calls = {}
+
+    def fake_cat(category, **kwargs):
+        calls["cat"] = category
+        calls.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "agentic_index_cli.internal.inject_readme.write_category_readme", fake_cat
+    )
+    script = Path(__file__).resolve().parents[1] / "scripts" / "inject_readme.py"
+    sys.argv = [str(script), "--category", "Foo"]
+    runpy.run_path(script, run_name="__main__")
+    assert calls["cat"] == "Foo"
+
+
+def test_inject_script_all_categories(monkeypatch):
+    called = {}
+
+    def fake_all(**kwargs):
+        called.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "agentic_index_cli.internal.inject_readme.write_all_categories", fake_all
+    )
+    script = Path(__file__).resolve().parents[1] / "scripts" / "inject_readme.py"
+    sys.argv = [str(script), "--all-categories"]
+    runpy.run_path(script, run_name="__main__")
+    assert called != {}


### PR DESCRIPTION
## Summary
- add per-category README table generation helpers
- allow `scripts/inject_readme.py` to write a single category or all categories
- extend inject CLI tests for new options
- test write_category_readme and write_all_categories

## Testing
- `black agentic_index_cli/internal/inject_readme.py tests/test_category_readme.py scripts/inject_readme.py tests/test_inject_cli_script.py`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850650eb070832a90f21b488c737205