### PR TITLE
Add category-aware refresh script

### DIFF
--- a/scripts/refresh_category.py
+++ b/scripts/refresh_category.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Refresh data for a single category."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# allow running from repo root
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import agentic_index_cli.internal.inject_readme as inj
+from agentic_index_cli.enricher import enrich
+from agentic_index_cli.internal.rank import main as rank
+from api.sync import sync
+
+TOPIC_MAP = {
+    "Frameworks": ["framework"],
+    "Multi-Agent Coordination": ["multi-agent", "crew"],
+    "RAG-centric": ["rag"],
+    "DevTools": ["devtool", "tool"],
+    "Domain-Specific": ["video", "game", "finance", "security"],
+    "Experimental": ["experiment", "research"],
+}
+
+
+def refresh(category: str, out_dir: Path) -> None:
+    topics = TOPIC_MAP.get(category)
+    if topics is None:
+        raise SystemExit(f"Unknown category: {category}")
+
+    repos = sync(topics=topics)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    data_path = out_dir / "repos.json"
+    data_path.write_text(json.dumps({"repos": repos}, indent=2) + "\n")
+
+    enrich(data_path)
+    rank(str(data_path))
+
+    inj.REPOS_PATH = out_dir / "by_category" / f"{category}.json"
+    inj.README_PATH = Path(f"README_{category}.md")
+    inj.main(force=True)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Refresh data for a category")
+    parser.add_argument("category")
+    parser.add_argument("--output", default="data")
+    args = parser.parse_args(argv)
+
+    refresh(args.category, Path(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trigger_refresh.sh
+++ b/scripts/trigger_refresh.sh
@@ -1,20 +1,46 @@
 #!/usr/bin/env bash
 
-# Trigger the update workflow for Agentic Index
+# Trigger the update workflow for Agentic Index or a specific category
 set -euo pipefail
 
-if ! command -v gh >/dev/null 2>&1; then
-  echo "Error: GitHub CLI 'gh' not found. Install from https://cli.github.com/." >&2
-  exit 1
-fi
+CATEGORIES=(
+  "Frameworks"
+  "Multi-Agent Coordination"
+  "RAG-centric"
+  "DevTools"
+  "Domain-Specific"
+  "Experimental"
+)
 
-if ! gh auth status >/dev/null 2>&1; then
-  echo "Error: GitHub CLI is not authenticated. Run 'gh auth login' or set GH_TOKEN." >&2
-  exit 1
-fi
+run_category() {
+  local cat="$1"
+  ./scripts/refresh_category.py "$cat"
+}
 
-gh workflow run update.yml \
-  -f ref=main \
-  -f min-stars="${1:-50}" \
-  -f auto-merge="true"
+case "${1:-}" in
+  --all)
+    for c in "${CATEGORIES[@]}"; do
+      run_category "$c"
+    done
+    ;;
+  "")
+    if ! command -v gh >/dev/null 2>&1; then
+      echo "Error: GitHub CLI 'gh' not found. Install from https://cli.github.com/." >&2
+      exit 1
+    fi
+
+    if ! gh auth status >/dev/null 2>&1; then
+      echo "Error: GitHub CLI is not authenticated. Run 'gh auth login' or set GH_TOKEN." >&2
+      exit 1
+    fi
+
+    gh workflow run update.yml \
+      -f ref=main \
+      -f min-stars="50" \
+      -f auto-merge="true"
+    ;;
+  *)
+    run_category "$1"
+    ;;
+esac
 


### PR DESCRIPTION
## Summary
- add new `refresh_category.py` to run the pipeline for a single category
- extend `trigger_refresh.sh` with `--all` and category support

## Testing
- `black --check .`
- `isort --check-only .`
- `CI_OFFLINE=1 PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685065245bec832ab2e67d48e9be06c0