### PR TITLE
Add category navigation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This catalogue is maintained by the Agentic-Index project and is updated regular
   * [💎 Honourable Mentions / Niche & Novel Gems](HONOURABLE.md)
     * [🔬 Our Methodology & Scoring Explained](#our-methodology--scoring-explained)
     * [🏷️ Category Definitions](#-category-definitions)
+  * [📚 Explore by Category](#-explore-by-category)
   * [🔄 Changelog](#-changelog)
   * [🏗 Architecture](#-architecture)
   * [🔧 Usage](#-usage)
@@ -211,6 +212,11 @@ Quick guide to our categories (and the icons you'll see in the table):
   * 🛠️ **DevTools:** Libraries and platforms to help you build, test, deploy, or secure agents (e.g., `msoedov/agentic_security` [23]).
   * 🧪 **Experimental:** Bleeding-edge, research-heavy, or early-stage projects (e.g., BabyAGI [3]).
 
+<a id="-explore-by-category"></a>
+## 📚 Explore by Category
+<!-- CATEGORY:START -->
+
+<!-- CATEGORY:END -->
 -----
 
 <a id="-changelog"></a>

--- a/agentic_index_cli/internal/inject_readme.py
+++ b/agentic_index_cli/internal/inject_readme.py
@@ -16,6 +16,19 @@ DATA_PATH = ROOT / "data" / "top100.md"
 REPOS_PATH = ROOT / "data" / "repos.json"
 RANKED_PATH = ROOT / "data" / "ranked.json"
 SNAPSHOT = ROOT / "data" / "last_snapshot.json"
+BY_CAT_INDEX = ROOT / "data" / "by_category" / "index.json"
+
+CATEGORY_START = "<!-- CATEGORY:START -->"
+CATEGORY_END = "<!-- CATEGORY:END -->"
+
+CATEGORY_ICONS = {
+    "General-purpose": "🌐",
+    "Multi-Agent Coordination": "🤖",
+    "RAG-centric": "📚",
+    "Domain-Specific": "🎯",
+    "DevTools": "🛠️",
+    "Experimental": "🧪",
+}
 
 DEFAULT_SORT_FIELD = "score"
 
@@ -184,6 +197,47 @@ def _fmt_delta(val: str | int | float, *, is_int: bool = False) -> str:
         return val
 
 
+def _build_category_list(index_path: pathlib.Path | None = None) -> str:
+    """Return markdown bullet list for category navigation."""
+    if index_path is None:
+        index_path = BY_CAT_INDEX
+    if not index_path.exists():
+        return ""
+    try:
+        index = json.loads(index_path.read_text())
+    except Exception:
+        return ""
+    lines: list[str] = []
+    for cat in sorted(index):
+        info = index[cat]
+        if isinstance(info, str):
+            fname = info
+            topics: list[str] = []
+        else:
+            fname = info.get("file") or info.get("path") or f"{cat}.json"
+            topics = info.get("topics", [])
+        md_name = f"README_{pathlib.Path(fname).stem}.md"
+        emoji = CATEGORY_ICONS.get(cat, "•")
+        topic_line = ""
+        if topics:
+            topic_line = "  \n_Topics: `" + "`, `".join(topics[:3]) + "`_"
+        lines.append(f"- {emoji} [{cat}]({md_name}){topic_line}")
+    return "\n".join(lines)
+
+
+def _inject_category_section(text: str) -> str:
+    """Inject category navigation section if markers are present."""
+    try:
+        start = text.index(CATEGORY_START)
+        end = text.index(CATEGORY_END, start)
+    except ValueError:
+        return text
+    body = _build_category_list()
+    before = text[: start + len(CATEGORY_START)].rstrip()
+    after = "\n" + text[end + len(CATEGORY_END) :].lstrip()
+    return f"{before}\n{body}\n{CATEGORY_END}{after}"
+
+
 def build_readme(
     *,
     sort_by: str = DEFAULT_SORT_FIELD,
@@ -218,6 +272,7 @@ def build_readme(
     table = "\n".join(header_lines + rows)
 
     new_text = f"{before}\n{table}\n{end_marker}{after}"
+    new_text = _inject_category_section(new_text)
     if os.getenv("PYTEST_CURRENT_TEST") is None:
         ts = datetime.datetime.utcnow().isoformat(timespec="seconds")
         new_text = new_text.replace("{timestamp}", ts)

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -53,6 +53,7 @@ This catalogue is maintained by the Agentic-Index project and is updated regular
   * [💎 Honourable Mentions / Niche & Novel Gems](HONOURABLE.md)
     * [🔬 Our Methodology & Scoring Explained](#our-methodology--scoring-explained)
     * [🏷️ Category Definitions](#-category-definitions)
+  * [📚 Explore by Category](#-explore-by-category)
   * [🔄 Changelog](#-changelog)
   * [🏗 Architecture](#-architecture)
   * [🔧 Usage](#-usage)
@@ -209,6 +210,11 @@ Quick guide to our categories (and the icons you'll see in the table):
   * 🎯 **Domain-Specific:** Tools built for specific industries or tasks (e.g., `video-db/Director` [22]).
   * 🛠️ **DevTools:** Libraries and platforms to help you build, test, deploy, or secure agents (e.g., `msoedov/agentic_security` [23]).
   * 🧪 **Experimental:** Bleeding-edge, research-heavy, or early-stage projects (e.g., BabyAGI [3]).
+
+<a id="-explore-by-category"></a>
+## 📚 Explore by Category
+<!-- CATEGORY:START -->
+<!-- CATEGORY:END -->
 
 -----
 

--- a/tests/test_category_section.py
+++ b/tests/test_category_section.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+import agentic_index_cli.internal.inject_readme as inj
+
+
+def test_category_section_injected(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    by_cat = data_dir / "by_category"
+    by_cat.mkdir(parents=True)
+
+    index = {
+        "DevTools": {"file": "DevTools.json", "topics": ["agents", "cli", "tools"]},
+        "NLP": "NLP.json",
+    }
+    (by_cat / "index.json").write_text(json.dumps(index))
+
+    (data_dir / "repos.json").write_text('{"schema_version":3,"repos":[]}')
+    (data_dir / "top100.md").write_text(
+        "| Rank | Repo | Score | Stars | Δ Stars | Δ Score | Recency | Issue Health | Doc Complete | License Freedom | Ecosystem | log₂(Stars) | Category |\n|-----:|------|------:|------:|--------:|--------:|-------:|-------------:|-------------:|---------------:|---------:|------------:|----------|\n"
+    )
+    (data_dir / "last_snapshot.json").write_text("[]")
+
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "start\n<!-- TOP50:START -->\nfoo\n<!-- TOP50:END -->\n<!-- CATEGORY:START -->\nold\n<!-- CATEGORY:END -->\nend\n"
+    )
+
+    for name, val in {
+        "README_PATH": readme,
+        "DATA_PATH": data_dir / "top100.md",
+        "REPOS_PATH": data_dir / "repos.json",
+        "SNAPSHOT": data_dir / "last_snapshot.json",
+        "BY_CAT_INDEX": by_cat / "index.json",
+    }.items():
+        setattr(inj, name, val)
+
+    assert inj.main(top_n=50) == 0
+    out = readme.read_text()
+    assert "README_DevTools.md" in out
+    assert "`agents`, `cli`, `tools`" in out
+    assert "README_NLP.md" in out


### PR DESCRIPTION
Closes #CR-AI-105D

## Summary
- add "Explore by Category" links in README
- generate category list in `inject_readme`
- snapshot updated and new test for category section

## Testing
- `black --check .`
- `isort --check-only .`
- `CI_OFFLINE=1 PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850654689a4832a9cf075cc1671ae11