### PR TITLE
Fix category output generation

### DIFF
--- a/agentic_index_cli/internal/inject_readme.py
+++ b/agentic_index_cli/internal/inject_readme.py
@@ -234,6 +234,13 @@ def _build_category_list(index_path: pathlib.Path | None = None) -> str:
         else:
             fname = info.get("file") or info.get("path") or f"{cat}.json"
             topics = info.get("topics", [])
+        if not topics:
+            try:
+                data = json.loads((index_path.parent / fname).read_text())
+                repos = data.get("repos", data)
+                topics = _infer_topics(repos)
+            except Exception:
+                topics = []
         md_name = f"README_{pathlib.Path(fname).stem}.md"
         emoji = CATEGORY_ICONS.get(cat, "•")
         topic_line = ""

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -51,6 +51,13 @@ To mimic CI's network restrictions use:
 CI_OFFLINE=1 pytest --disable-socket
 ```
 
+### Generating Category READMEs
+After running the ranking pipeline you can create one `README_<Category>.md` per
+category with:
+```bash
+python scripts/inject_readme.py --all-categories
+```
+
 ## Troubleshooting
 - **Network errors when installing packages** – use the mirror described in [docs/CI_SETUP.md](CI_SETUP.md).
 - **GitHub API rate limits** – export `GITHUB_TOKEN_REPO_STATS` with a personal token or lower `--min-stars` when scraping.

--- a/scripts/refresh_category.py
+++ b/scripts/refresh_category.py
@@ -39,9 +39,17 @@ def refresh(category: str, out_dir: Path) -> None:
     enrich(data_path)
     rank(str(data_path))
 
-    inj.REPOS_PATH = out_dir / "by_category" / f"{category}.json"
-    inj.README_PATH = Path(f"README_{category}.md")
-    inj.main(force=True)
+    by_cat = out_dir / "by_category"
+    inj.REPOS_PATH = data_path
+    inj.write_category_readme(category, force=True)
+
+    index_file = by_cat / "index.json"
+    try:
+        current = json.loads(index_file.read_text())
+    except Exception:
+        current = {}
+    current[category] = f"{category}.json"
+    index_file.write_text(json.dumps(current, indent=2) + "\n")
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/tests/test_category_cli_integration.py
+++ b/tests/test_category_cli_integration.py
@@ -1,0 +1,71 @@
+import json
+import runpy
+import sys
+from pathlib import Path
+
+import agentic_index_cli.agentic_index as ai
+import agentic_index_cli.enricher as enricher
+import agentic_index_cli.internal.inject_readme as inj
+import agentic_index_cli.internal.rank as rank
+
+
+def test_cli_all_categories(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    repos = [
+        {
+            "name": "a",
+            "full_name": "o/a",
+            "stargazers_count": 10,
+            "forks_count": 0,
+            "open_issues_count": 0,
+            "pushed_at": "2025-01-01T00:00:00Z",
+            "owner": {"login": "o"},
+            "AgenticIndexScore": 1.0,
+            "category": "Dummy1",
+            "description": "Dummy1",
+            "topics": ["foo"],
+        },
+        {
+            "name": "b",
+            "full_name": "o/b",
+            "stargazers_count": 5,
+            "forks_count": 0,
+            "open_issues_count": 0,
+            "pushed_at": "2025-01-02T00:00:00Z",
+            "owner": {"login": "o"},
+            "AgenticIndexScore": 2.0,
+            "category": "Dummy2",
+            "description": "Dummy2",
+            "topics": ["bar"],
+        },
+    ]
+    data = {"schema_version": 3, "repos": repos}
+    data_path = data_dir / "repos.json"
+    data_path.write_text(json.dumps(data))
+    (data_dir / "top100.md").write_text("")
+    (data_dir / "last_snapshot.json").write_text("[]")
+
+    for name, val in {
+        "ROOT": tmp_path,
+        "REPOS_PATH": data_path,
+        "DATA_PATH": data_dir / "top100.md",
+        "SNAPSHOT": data_dir / "last_snapshot.json",
+    }.items():
+        setattr(inj, name, val)
+
+    monkeypatch.setattr(rank, "infer_category", lambda repo: repo["category"])
+    monkeypatch.setattr(ai, "categorize", lambda desc, topics: desc)
+    monkeypatch.setattr(enricher, "categorize", lambda desc, topics: desc)
+    enricher.enrich(data_path)
+    rank.main(str(data_path))
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "inject_readme.py"
+    sys.argv = [str(script), "--all-categories"]
+    runpy.run_path(script, run_name="__main__")
+
+    for cat in ["Dummy1", "Dummy2"]:
+        path = tmp_path / f"README_{cat}.md"
+        assert path.exists()
+        text = path.read_text()
+        assert f"Top Agentic-AI Repositories: {cat}" in text

--- a/tests/test_category_section.py
+++ b/tests/test_category_section.py
@@ -15,6 +15,12 @@ def test_category_section_injected(tmp_path, monkeypatch):
     }
     (by_cat / "index.json").write_text(json.dumps(index))
 
+    (by_cat / "NLP.json").write_text(
+        json.dumps(
+            {"schema_version": 3, "repos": [{"topics": ["nlp"], "category": "NLP"}]}
+        )
+    )
+
     (data_dir / "repos.json").write_text('{"schema_version":3,"repos":[]}')
     (data_dir / "top100.md").write_text(
         "| Rank | Repo | Score | Stars | Δ Stars | Δ Score | Recency | Issue Health | Doc Complete | License Freedom | Ecosystem | log₂(Stars) | Category |\n|-----:|------|------:|------:|--------:|--------:|-------:|-------------:|-------------:|---------------:|---------:|------------:|----------|\n"
@@ -37,6 +43,15 @@ def test_category_section_injected(tmp_path, monkeypatch):
 
     assert inj.main(top_n=50) == 0
     out = readme.read_text()
-    assert "README_DevTools.md" in out
-    assert "`agents`, `cli`, `tools`" in out
-    assert "README_NLP.md" in out
+    start = out.index("<!-- CATEGORY:START -->") + len("<!-- CATEGORY:START -->")
+    end = out.index("<!-- CATEGORY:END -->", start)
+    snippet = out[start:end].strip()
+    expected = "\n".join(
+        [
+            "- 🛠️ [DevTools](README_DevTools.md)  ",
+            "_Topics: `agents`, `cli`, `tools`_",
+            "- • [NLP](README_NLP.md)  ",
+            "_Topics: `nlp`_",
+        ]
+    )
+    assert snippet == expected

--- a/tests/test_refresh_category_integration.py
+++ b/tests/test_refresh_category_integration.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+import agentic_index_cli.internal.rank as rank_mod
+from scripts import refresh_category
+
+
+def test_refresh_generates_by_category(tmp_path, monkeypatch):
+    def fake_sync(topics=None, org=None):
+        return [
+            {
+                "name": "r",
+                "full_name": "o/r",
+                "stargazers_count": 1,
+                "forks_count": 0,
+                "open_issues_count": 0,
+                "pushed_at": "2025-01-01T00:00:00Z",
+                "owner": {"login": "o"},
+                "license": {"spdx_id": "MIT"},
+                "topics": ["t"],
+            }
+        ]
+
+    monkeypatch.setattr(refresh_category, "sync", fake_sync)
+    monkeypatch.setattr(rank_mod, "infer_category", lambda repo: "Experimental")
+
+    out_dir = tmp_path / "data"
+    refresh_category.refresh("Experimental", out_dir)
+
+    by_cat = out_dir / "by_category"
+    assert (by_cat / "Experimental.json").exists()
+    index = json.loads((by_cat / "index.json").read_text())
+    assert index == {"Experimental": "Experimental.json"}


### PR DESCRIPTION
Closes #115

## Summary
- restore per-category output generation via refresh script
- include topics from category JSONs when injecting README navigation
- add CLI tests for category README generation
- update docs with instructions

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68506d16dd0c832a941397f8a7236f91