### PR TITLE
Fix CLI module path

### DIFF
--- a/scripts/rank.py
+++ b/scripts/rank.py
@@ -2,6 +2,11 @@
 """CLI wrapper for ranking repositories."""
 
 import argparse
+import sys
+from pathlib import Path
+
+# ensure agentic_index_cli is importable when executed via `python scripts/rank.py`
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from agentic_index_cli.config import load_config
 from agentic_index_cli.internal.rank import generate_badges, main


### PR DESCRIPTION
Closes #128

## Summary
- ensure `agentic_index_cli` is importable when invoking the rank script directly

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507c1a885c832aa2fa22c01474db9b