### PR TITLE
Update test expectations for 6-column README

### DIFF
--- a/tests/test_inject_dry_run.py
+++ b/tests/test_inject_dry_run.py
@@ -82,7 +82,7 @@ def _change_cell(text: str, col: int, value: str) -> str:
     [
         (lambda txt: _bump_score(txt, 0.015), True),
         (lambda txt: _bump_score(txt, 0.05), False),
-        (lambda txt: _change_cell(txt, 12, "MIT"), False),
+        (lambda txt: _change_cell(txt, 5, "MIT"), False),
         (lambda txt: _change_cell(txt, 0, "2"), False),
     ],
 )

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -14,16 +14,12 @@ def test_readme_synced():
     lines = [l for l in text[start:end].splitlines() if l.startswith("|")]
     for line in lines[2:]:
         cells = [c.strip() for c in line.strip().strip("|").split("|")]
-        assert len(cells) >= 13
+        assert len(cells) == 6
         int(cells[0])
-        float(cells[2])
-        int(cells[3])
-        if cells[4] and cells[4] != "+new":
-            int(cells[4].replace("+", ""))
+        float(cells[3])
+        int(cells[4])
         if cells[5] and cells[5] != "+new":
-            float(cells[5].replace("+", ""))
-        if cells[6] != "-":
-            float(cells[6])
+            int(cells[5].replace("+", ""))
 
 
 def test_inject_idempotent(tmp_path):


### PR DESCRIPTION
## Summary
- update dry-run mutation test to use new column index
- expect 6 columns in README sync checks

## Testing
- `pytest -q` *(fails: Missing test dependencies: responses, pytest_socket)*

------
https://chatgpt.com/codex/tasks/task_e_68507c0e14cc832a91f02c3119de1324