### PR TITLE
CI: validate README fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,27 @@ jobs:
         with:
           name: coverage
           path: coverage.xml
+  fixtures-validate:
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: Install deps
+        run: |
+          pip install -r requirements.txt
+          pip install -e '.[dev]'
+      - name: Validate fixtures
+        run: python scripts/validate_fixtures.py
+
 
   pipeline-integrity:
     needs: tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,11 @@ repos:
         types: [markdown]
         pass_filenames: false
         files: README\.md
+      - id: fixtures-validate
+        name: Validate README fixtures
+        entry: python scripts/validate_fixtures.py
+        language: system
+        pass_filenames: false
       - id: pytest
         name: pytest
         entry: pytest --quiet --cov=agentic_index_cli --cov-fail-under=0

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,9 @@ top100:
 	python scripts/score_metrics.py data/repos.json
 	python -m agentic_index_cli.ranker data/repos.json
 	python scripts/inject_readme.py --force
+
+
+regen-fixtures:
+	python scripts/inject_readme.py --force --top-n 50
+	cp README.md tests/fixtures/README_fixture.md
+

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -1,0 +1,16 @@
+# Developer Contributing Notes
+
+This section supplements the main [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Regenerating Fixtures
+
+Tests rely on a snapshot of the README stored in `tests/fixtures/README_fixture.md`.
+Whenever `scripts/inject_readme.py` changes or you update the ranking data,
+regenerate the fixture so it stays in sync:
+
+```bash
+make regen-fixtures
+```
+
+The command rebuilds `README.md` and copies the result into the fixture file.
+Pre-commit and CI will fail if the snapshot drifts.

--- a/scripts/validate_fixtures.py
+++ b/scripts/validate_fixtures.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Validate README fixtures are up to date."""
+
+from __future__ import annotations
+
+import difflib
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests" / "fixtures" / "README_fixture.md"
+
+
+def _generate_readme() -> str:
+    """Return README text produced by the injector."""
+    from agentic_index_cli.internal import inject_readme as inj
+
+    return inj.build_readme(top_n=50, limit=50).strip()
+
+
+def main() -> int:
+    # Run the CLI in dry-run mode so failure is reported if README.md is stale.
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "inject_readme.py"),
+        "--dry-run",
+        "--top-n",
+        "50",
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode not in (0, 1):
+        sys.stderr.write(res.stderr)
+        return res.returncode
+
+    generated = _generate_readme()
+    expected = FIXTURE.read_text().strip()
+
+    if generated != expected:
+        diff = difflib.unified_diff(
+            expected.splitlines(True),
+            generated.splitlines(True),
+            fromfile=str(FIXTURE),
+            tofile="generated",
+        )
+        print("Fixture drift detected:")
+        for line in diff:
+            print(line, end="")
+        return 1
+    return res.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #129

## Summary
- validate README fixture in pre-commit and CI
- add `regen-fixtures` helper
- document fixture regeneration steps

## Testing
- `black --check .`
- `isort --check-only .`
- `CI_OFFLINE=1 PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507c1da86c832ab0484b84a42e8e6a