### PR TITLE
Fix CLI module import setup

### DIFF
--- a/docs/CI_SETUP.md
+++ b/docs/CI_SETUP.md
@@ -9,3 +9,14 @@ pip install -i https://pypi.org/simple \
 ```
 
 Using this mirror (Option B) avoids firewall issues while keeping the installation steps simple.
+
+## Example Workflow Step
+
+Install the package in editable mode and run the ranking command:
+
+```yaml
+- name: Install dependencies
+  run: pip install -e .
+- name: Run ranking script
+  run: agentic-index rank data/repos.json
+```

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -14,3 +14,12 @@ make regen-fixtures
 
 The command rebuilds `README.md` and copies the result into the fixture file.
 Pre-commit and CI will fail if the snapshot drifts.
+
+## Editable Install
+
+After cloning the repository, install the CLI in editable mode so the
+`agentic-index` command is available on your path:
+
+```bash
+pip install -e .
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ fail_under = 70  # temporary threshold, will be raised after snapshot tolerance 
 
 [tool.isort]
 profile = "black"
+
+[tool.setuptools.packages.find]
+exclude = ["tests*", "docs*", "scripts*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,7 @@ install_requires =
 [options.entry_points]
 console_scripts =
     agentic-index = agentic_index_cli.__main__:main
+
+[options.packages.find]
+exclude =
+    tests*


### PR DESCRIPTION
Closes #128

## Summary
- package CLI as installable by excluding non-code directories
- document editable install instructions for developers
- show GitHub Actions snippet for running the CLI

## Testing
- `black --check .`
- `isort --check-only .`
- `CI_OFFLINE=1 PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d90d4ff8832ab6038ef8c2753abd