### PR TITLE
ci: schedule README injector

### DIFF
--- a/.github/workflows/inject-readme.yml
+++ b/.github/workflows/inject-readme.yml
@@ -1,0 +1,41 @@
+name: Daily README Injection
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force README injection outside schedule'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  inject-readme:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'schedule'
+      || (github.event_name == 'workflow_dispatch' && github.event.inputs.force == 'true')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -e '.[dev]'
+      - name: Run README Injection
+        run: python -m agentic_index_cli.internal.inject_readme --all
+      - name: Commit & Push Changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          if ! git diff --quiet; then
+            git commit -m "chore: daily README table update"
+            git push
+          else
+            echo "No changes to inject."
+          fi

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -29,7 +29,6 @@ jobs:
           python scripts/scrape_repos.py --min-stars 50 --output data/repos.json
           python scripts/score_metrics.py data/repos.json
           python -m agentic_index_cli.ranker data/repos.json
-          python scripts/inject_readme.py
           git diff --quiet || echo "CHANGES_DETECTED=true" >> "$GITHUB_ENV"
       - name: Verify artifacts
         run: |

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -14,3 +14,9 @@ make regen-fixtures
 
 The command rebuilds `README.md` and copies the result into the fixture file.
 Pre-commit and CI will fail if the snapshot drifts.
+
+README tables are injected automatically by CI once per day. You can trigger an
+immediate update via GitHub:
+
+1. Navigate to **Actions** → **Daily README Injection**.
+2. Click **Run workflow** and set `force` to `true`.


### PR DESCRIPTION
Closes #130

## Summary
- extract README injection into a new workflow triggered daily or via manual dispatch
- remove injection step from refresh workflow
- document how to manually run the daily injector

## Testing
- `black --check .`
- `isort --check-only .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850da97c9b0832a99f2e5cf62ecdcae