### PR TITLE
Harden workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/rank.yml
+++ b/.github/workflows/rank.yml
@@ -5,11 +5,12 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: write
+
 jobs:
   run:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -21,7 +22,7 @@ jobs:
         run: |
           echo "running ranker"
           # Placeholder for ranking logic generating repos.json
-          python scripts/ranker.py || true
+          python scripts/ranker.py
       - name: Archive repos.json
         run: |
           mkdir -p data/history


### PR DESCRIPTION
## Summary
- set least-privilege permissions for CI workflows
- remove failure masking from ranking job

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q` *(fails: test_inject_dry_run.py)*

------
https://chatgpt.com/codex/tasks/task_e_6851346a6314832a9183a6b9c8e83103