### PR TITLE
Harden GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: true
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
@@ -82,6 +83,15 @@ jobs:
         with:
           name: coverage
           path: coverage.xml
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts
+          path: |
+            data/history/*.json
+            *.log
+          if-no-files-found: ignore
   fixtures-validate:
     needs: tests
     runs-on: ubuntu-latest
@@ -127,6 +137,15 @@ jobs:
           CI_OFFLINE: '1'
         run: |
           pytest -q tests/test_pipeline_integration.py tests/test_refresh_category_integration.py
+      - name: Upload pipeline artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-artifacts
+          path: |
+            data/history/*.json
+            *.log
+          if-no-files-found: ignore
 
   security-scan:
     runs-on: ubuntu-latest
@@ -155,6 +174,9 @@ jobs:
 
   badge-update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     needs: [tests, security-scan]
     if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
     steps:

--- a/.github/workflows/rank.yml
+++ b/.github/workflows/rank.yml
@@ -6,11 +6,13 @@ on:
     - cron: '0 0 * * 0'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -20,9 +22,9 @@ jobs:
         run: pip install matplotlib
       - name: Run ranker
         run: |
-          echo "running ranker"
+          echo "running ranker" | tee rank.log
           # Placeholder for ranking logic generating repos.json
-          python scripts/ranker.py
+          python scripts/ranker.py >> rank.log 2>&1
       - name: Archive repos.json
         run: |
           mkdir -p data/history
@@ -35,4 +37,17 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Update history and trends
+      - name: Upload history
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rank-history
+          path: data/history/*.json
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rank-logs
+          path: rank.log
+          if-no-files-found: ignore
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,8 +19,7 @@ on:
         required: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update-data:
@@ -42,16 +41,16 @@ jobs:
           pip install -e .
       - name: Run scraper & enrichment
         run: |
-          python -m agentic_index_cli.scraper --min-stars $MIN_STARS
-          python -m agentic_index_cli.enricher data/repos.json
+          python -m agentic_index_cli.scraper --min-stars $MIN_STARS 2>&1 | tee update.log
+          python -m agentic_index_cli.enricher data/repos.json 2>&1 | tee -a update.log
       - name: Validate data
-        run: python -m agentic_index_cli.validate data/repos.json
+        run: python -m agentic_index_cli.validate data/repos.json >> update.log 2>&1
       - name: Rank repositories
-        run: python -m agentic_index_cli.ranker data/repos.json
+        run: python -m agentic_index_cli.ranker data/repos.json >> update.log 2>&1
       - name: Run tests
         env:
           CI_OFFLINE: '1'
-        run: pytest -q
+        run: pytest -q >> update.log 2>&1
       - name: Check for updated index
         id: detect-changes
         shell: bash
@@ -84,3 +83,16 @@ jobs:
           github_token: ${{ github.token }}
           pull_request: ${{ steps.createpr.outputs.pull-request-number }}
           merge_method: squash
+      - name: Upload history
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: update-history
+          path: data/history/*.json
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: update-logs
+          path: update.log
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- enforce fail-fast in the CI matrix
- tighten permissions for CI badge update job
- limit workflow tokens in rank.yml and update.yml
- collect history JSONs and logs as artifacts for debugging

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851434ea9a0832a98f1bd4fa392079b