### PR TITLE
Fix scrape tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         name: pytest
         entry: pytest --quiet --cov=agentic_index_cli --cov-fail-under=0
         language: python
-        additional_dependencies: [., pytest, pytest-cov, requests, PyYAML, jsonschema, pydantic, responses, pytest-socket, pytest-env, "typer[all]", matplotlib, fastapi, httpx, rich, click]
+        additional_dependencies: [., pytest, pytest-cov, requests, PyYAML, jsonschema, pydantic, responses, pytest-socket, pytest-env, "typer[all]", matplotlib, fastapi, httpx, aiohttp, rich, click]
         files: \.py$
         exclude: ^scripts/(score_metrics|propagate_pr_tasks)\.py$
       - id: detect-large-files


### PR DESCRIPTION
Closes #291

## Summary
- add missing imports for tests
- ensure pytest hook installs aiohttp

## Testing
- `pre-commit run --files tests/test_scrape_mock.py .pre-commit-config.yaml`
- `PYTHONPATH="$PWD" pytest tests/test_scrape_mock.py -q`
- `PYTHONPATH="$PWD" pytest -q` *(fails: Score mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_685149746c70832a8ad0119bd4e850e4