### PR TITLE
Add logging and error details for protected API routes

### DIFF
--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -24,6 +24,7 @@ def test_protected_requires_auth(monkeypatch):
     for path in ["/sync", "/score", "/render", "/issue"]:
         resp = client.post(path)
         assert resp.status_code == 401
+        assert resp.json() == {"detail": "unauthorized"}
 
 
 def test_api_key_header(monkeypatch, tmp_path):
@@ -47,6 +48,14 @@ def test_api_key_header(monkeypatch, tmp_path):
         "/issue", json={"repo": "o/r", "title": "t"}, headers={"X-API-KEY": "sekret"}
     )
     assert resp.status_code == 200
+
+
+def test_invalid_api_key(monkeypatch):
+    app, _ = load_app(monkeypatch, key="sekret")
+    client = TestClient(app)
+    resp = client.post("/sync", headers={"X-API-KEY": "wrong"})
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "unauthorized"}
 
 
 def test_ip_whitelist(monkeypatch):


### PR DESCRIPTION
Closes #318

## Summary
- log request path, IP, and API key validity for protected routes
- return structured unauthorized responses
- test missing, invalid, and whitelisted keys

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q` *(fails: tests/test_inject_dry_run.py::test_inject_readme_check ...)*

------
https://chatgpt.com/codex/tasks/task_e_68521de0ba28832a9975e970e6a305d1