### PR TITLE
Add coverage for dry-run and score top5

### DIFF
--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,5 +1,6 @@
 import importlib
 
+import pytest
 from fastapi.testclient import TestClient
 
 import agentic_index_api.server as srv
@@ -27,8 +28,14 @@ def test_protected_requires_auth(monkeypatch):
         assert resp.json() == {"detail": "unauthorized"}
 
 
-def test_api_key_header(monkeypatch, tmp_path):
-    app, mod = load_app(monkeypatch, key="sekret")
+@pytest.mark.parametrize("mode", ["header", "ip"])
+def test_auth_valid(monkeypatch, tmp_path, mode):
+    if mode == "header":
+        app, mod = load_app(monkeypatch, key="sekret")
+        headers = {"X-API-KEY": "sekret"}
+    else:
+        app, mod = load_app(monkeypatch, ips="testclient")
+        headers = {}
     monkeypatch.setattr(mod, "scrape", lambda *a, **k: [])
     monkeypatch.setattr(mod, "save_repos", lambda *a, **k: None)
     sync = tmp_path / "sync.json"
@@ -42,11 +49,9 @@ def test_api_key_header(monkeypatch, tmp_path):
     monkeypatch.setattr(mod.issue_logger, "create_issue", lambda *a, **k: {})
     client = TestClient(app)
     for path in ["/sync", "/score", "/render"]:
-        resp = client.post(path, headers={"X-API-KEY": "sekret"})
+        resp = client.post(path, headers=headers)
         assert resp.status_code == 200
-    resp = client.post(
-        "/issue", json={"repo": "o/r", "title": "t"}, headers={"X-API-KEY": "sekret"}
-    )
+    resp = client.post("/issue", json={"repo": "o/r", "title": "t"}, headers=headers)
     assert resp.status_code == 200
 
 
@@ -56,15 +61,6 @@ def test_invalid_api_key(monkeypatch):
     resp = client.post("/sync", headers={"X-API-KEY": "wrong"})
     assert resp.status_code == 401
     assert resp.json() == {"detail": "unauthorized"}
-
-
-def test_ip_whitelist(monkeypatch):
-    app, mod = load_app(monkeypatch, ips="testclient")
-    monkeypatch.setattr(mod, "scrape", lambda *a, **k: [])
-    monkeypatch.setattr(mod, "save_repos", lambda *a, **k: None)
-    client = TestClient(app)
-    resp = client.post("/sync")
-    assert resp.status_code == 200
 
 
 def test_docs(monkeypatch):

--- a/tests/test_api_score.py
+++ b/tests/test_api_score.py
@@ -68,3 +68,30 @@ def test_score_invalid_file(tmp_path, monkeypatch):
     client = TestClient(app)
     resp = client.post("/score", json={}, headers={"X-API-KEY": "k"})
     assert resp.status_code == 400
+
+
+def test_score_returns_top_five(tmp_path, monkeypatch):
+    data = []
+    for i in range(7):
+        data.append(
+            {
+                "name": f"repo{i}",
+                "stargazers_count": 5 * i + 1,
+                "open_issues_count": 0,
+                "closed_issues": 10 * i + 1,
+                "pushed_at": f"2025-06-{i+1:02d}T00:00:00Z",
+                "license": {"spdx_id": "MIT"},
+                "doc_completeness": 0.5,
+                "ecosystem_integration": 0.0,
+            }
+        )
+    client, headers = make_client(monkeypatch, tmp_path, data)
+    resp = client.post("/score", json={}, headers=headers)
+    assert resp.status_code == 200
+    returned = resp.json()["top_scores"]
+
+    expected = [{"name": r["name"], "score": compute_score(r)} for r in data]
+    expected.sort(key=lambda r: r["score"], reverse=True)
+
+    assert len(returned) == 5
+    assert returned == expected[:5]

--- a/tests/test_inject_readme_unit.py
+++ b/tests/test_inject_readme_unit.py
@@ -101,3 +101,30 @@ def test_missing_repos_file(tmp_path, monkeypatch):
     inj.REPOS_PATH.unlink()
     with pytest.raises(FileNotFoundError):
         inj.build_readme(top_n=50)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "name",
+        "full_name",
+        "AgenticIndexScore",
+        "stars",
+        "stars_delta",
+        "score_delta",
+        "recency_factor",
+        "issue_health",
+        "doc_completeness",
+        "license_freedom",
+        "ecosystem_integration",
+        "stars_log2",
+        "category",
+    ],
+)
+def test_load_rows_missing_field(tmp_path, field):
+    _setup(tmp_path)
+    data = json.loads(inj.REPOS_PATH.read_text())
+    del data["repos"][0][field]
+    inj.REPOS_PATH.write_text(json.dumps(data))
+    with pytest.raises(KeyError, match=field):
+        inj._load_rows()

--- a/tests/test_issue_logger.py
+++ b/tests/test_issue_logger.py
@@ -232,3 +232,25 @@ def test_worklog_targets(monkeypatch):
         targets=["pr", "issue"],
     )
     assert url == "u"
+
+
+def test_cli_dry_run(monkeypatch, capsys):
+    def fake_create(*a, **k):
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(il, "create_issue", fake_create)
+    il.main(
+        [
+            "--new-issue",
+            "--repo",
+            "o/r",
+            "--title",
+            "t",
+            "--body",
+            "b",
+            "--dry-run",
+            "--verbose",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out


### PR DESCRIPTION
## Summary
- test `_load_rows` for missing fields
- test issue logger `--dry-run`
- verify top 5 results in `/score` endpoint
- parameterize auth tests to cover header/IP modes

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q` *(fails: Score mismatch in README fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_685221550968832a9f1adf0b7b8b8585