### PR TITLE
Update README force injection docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This catalogue is maintained by the Agentic-Index project and is updated regular
   * [🔧 Usage](#-usage)
   * [🔄 How refresh works](#-how-refresh-works)
   * [🧪 Testing](#-testing)
+  * [📝 Forcing README injection](#-forcing-readme-injection)
   * [🤝 How to Contribute](#-how-to-contribute)
   * [🛡 Code of Conduct](#-code-of-conduct)
   * [📜 License](#-license)
@@ -306,6 +307,16 @@ bash scripts/trigger_refresh.sh 75
 
 Replace `75` with your desired minimum star count. The script requires the GitHub CLI and an authenticated token.
 Set a personal access token via the `GITHUB_TOKEN_REPO_STATS` environment variable to avoid hitting rate limits when scraping.
+
+### 📝 Forcing README injection
+
+The injector normally skips writing `README.md` when no changes are detected. Use `--force` to rewrite the table regardless:
+
+```bash
+python scripts/inject_readme.py --force
+```
+
+This can be handy after metric tweaks that don't change rankings but should refresh the snapshot.
 
 -----
 

--- a/agentic_index_cli/inject_readme.py
+++ b/agentic_index_cli/inject_readme.py
@@ -8,7 +8,11 @@ def cli(argv=None):
     import argparse
 
     parser = argparse.ArgumentParser(description="Inject README table")
-    parser.add_argument("--force", action="store_true")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Write README even if no changes are detected",
+    )
     parser.add_argument("--top-n", type=int, default=DEFAULT_TOP_N)
     args = parser.parse_args(argv)
     main(force=args.force, top_n=args.top_n)

--- a/scripts/inject_readme.py
+++ b/scripts/inject_readme.py
@@ -30,7 +30,11 @@ if __name__ == "__main__":
         "--write", action="store_true", help="Update README in place (default)"
     )
     group.add_argument("--dry-run", action="store_true", help="Alias for --check")
-    parser.add_argument("--force", action="store_true", help="Write even if unchanged")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Write README even if no changes are detected",
+    )
     parser.add_argument(
         "--sort-by",
         default=DEFAULT_SORT_FIELD,

--- a/tests/fixtures/README_fixture.md
+++ b/tests/fixtures/README_fixture.md
@@ -49,6 +49,7 @@ This catalogue is maintained by the Agentic-Index project and is updated regular
   * [🔧 Usage](#-usage)
   * [🔄 How refresh works](#-how-refresh-works)
   * [🧪 Testing](#-testing)
+  * [📝 Forcing README injection](#-forcing-readme-injection)
   * [🤝 How to Contribute](#-how-to-contribute)
   * [🛡 Code of Conduct](#-code-of-conduct)
   * [📜 License](#-license)
@@ -306,6 +307,16 @@ bash scripts/trigger_refresh.sh 75
 
 Replace `75` with your desired minimum star count. The script requires the GitHub CLI and an authenticated token.
 Set a personal access token via the `GITHUB_TOKEN_REPO_STATS` environment variable to avoid hitting rate limits when scraping.
+
+### 📝 Forcing README injection
+
+The injector normally skips writing `README.md` when no changes are detected. Use `--force` to rewrite the table regardless:
+
+```bash
+python scripts/inject_readme.py --force
+```
+
+This can be handy after metric tweaks that don't change rankings but should refresh the snapshot.
 
 -----
 


### PR DESCRIPTION
## Summary
- document how to force README injection
- clarify CLI help text for the `--force` option

## Testing
- `CI_OFFLINE=1 PYTHONPATH="$PWD" pytest -q` *(fails: Score mismatch in README fixture)*
- `black --check agentic_index_cli/inject_readme.py scripts/inject_readme.py`
- `isort --check-only agentic_index_cli/inject_readme.py scripts/inject_readme.py`


------
https://chatgpt.com/codex/tasks/task_e_685246ae3fd4832ab1a8e6d6bbaa9483