### PR TITLE
Add coverage enforcement and pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,18 @@ jobs:
         env:
           PYTHONHASHSEED: 0
         run: pytest --cov=agentic_index_cli --cov-report=xml --full-trace
+      - name: Enforce coverage threshold
+        run: python scripts/coverage_gate.py coverage.xml
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage.xml
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,15 @@ repos:
     rev: v1.6.24
     hooks:
       - id: actionlint
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 black
 isort
 flake8
+coverage
 mypy
 bandit
 pre-commit

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -32,7 +32,8 @@ bash scripts/agent-setup.sh
 This installs `pre-commit` and performs a `pip install -e .` under the hood.
 
 ## Pre-commit Hooks
-Activate hooks so formatting and lint checks run before each commit:
+Activate hooks so formatting and lint checks run before each commit. The hooks
+run **Black**, **Isort**, **Flake8**, and the unit tests:
 ```bash
 pre-commit install
 ```


### PR DESCRIPTION
## Summary
- enforce coverage using coverage.py and Codecov upload in CI
- include Black, Isort and Flake8 in pre-commit config
- document the pre-commit workflow
- install coverage in dev requirements

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q` *(fails: Score mismatch tests)*

------
https://chatgpt.com/codex/tasks/task_e_68524ee89fe0832aa8f37a9577026f4b