### PR TITLE
Introduce structlog for structured logging

### DIFF
--- a/agentic_index_cli/logging_config.py
+++ b/agentic_index_cli/logging_config.py
@@ -1,0 +1,36 @@
+import logging
+import os
+import sys
+
+import structlog
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure structlog and stdlib logging."""
+    processors = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.format_exc_info,
+        structlog.processors.JSONRenderer(),
+    ]
+    logging.basicConfig(level=level, format="%(message)s", stream=sys.stdout)
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+
+def configure_sentry() -> None:
+    """Initialize Sentry if ``SENTRY_DSN`` is set."""
+    dsn = os.getenv("SENTRY_DSN")
+    if not dsn:
+        return
+    try:
+        import sentry_sdk
+
+        sentry_sdk.init(dsn=dsn)
+    except Exception:
+        logging.getLogger(__name__).warning("Failed to init sentry")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "jsonschema>=3.2",
     "pydantic>=2",
     "rich",
+    "structlog",
+    "sentry-sdk",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ uvicorn
 httpx
 pytest-env
 aiohttp>=3.9.0
+structlog
+sentry-sdk


### PR DESCRIPTION
## Summary
- add structlog-based logging configuration
- log request context in the API server
- enable CLI logging with structlog and optional Sentry support
- update dependencies for structlog and sentry-sdk

## Testing
- `black --check .`
- `isort --check-only .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_685253f5cac0832aa565b0dfd549686b