### PR TITLE
Add templating for markdown and daily guard

### DIFF
--- a/agentic_index_cli/helpers/once_per_day.py
+++ b/agentic_index_cli/helpers/once_per_day.py
@@ -1,0 +1,19 @@
+"""Utilities for once-per-day execution guards."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+
+
+def once_per_day(name: str, *, state_dir: Path | str = "state") -> bool:
+    """Return ``True`` if ``name`` has not run today."""
+
+    dir_path = Path(state_dir)
+    dir_path.mkdir(parents=True, exist_ok=True)
+    stamp = dir_path / f"{name}.date"
+    today = _dt.date.today().isoformat()
+    if stamp.exists() and stamp.read_text().strip() == today:
+        return False
+    stamp.write_text(today)
+    return True

--- a/scripts/generate_badges.py
+++ b/scripts/generate_badges.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 """Regenerate dynamic badges without running the full ranking pipeline."""
+import argparse
 import datetime
 import json
 from pathlib import Path
 
+from agentic_index_cli.helpers.once_per_day import once_per_day
 from agentic_index_cli.internal.rank import generate_badges
 
 
-def main(json_path: str = "data/repos.json") -> None:
+def main(json_path: str = "data/repos.json", *, force: bool = False) -> None:
+    if not force and not once_per_day("generate_badges"):
+        print("Badges already generated today", flush=True)
+        return
+
     path = Path(json_path)
     data = json.loads(path.read_text())
     repos = data.get("repos", data)
@@ -22,4 +28,10 @@ def main(json_path: str = "data/repos.json") -> None:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Regenerate dynamic badges")
+    parser.add_argument("json", nargs="?", default="data/repos.json")
+    parser.add_argument(
+        "--force", action="store_true", help="ignore once-per-day guard"
+    )
+    args = parser.parse_args()
+    main(args.json, force=args.force)

--- a/tests/test_once_per_day.py
+++ b/tests/test_once_per_day.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from agentic_index_cli.helpers.once_per_day import once_per_day
+
+
+def test_once_per_day(tmp_path):
+    state = tmp_path / "state"
+    assert once_per_day("foo", state_dir=state)
+    assert not once_per_day("foo", state_dir=state)
+    assert Path(state / "foo.date").exists()


### PR DESCRIPTION
## Summary
- add once_per-day helper for scripts
- use Jinja2 template for CSV markdown output
- gate badge generation behind once-per-day guard
- test daily guard behaviour

## Testing
- `black --check .`
- `isort --check-only .`
- `CI_OFFLINE=1 PYTHONPATH="$PWD" pytest -q` *(fails: Score mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68525c679f94832a954922e5776f2c7b