### PR TITLE
Add Jinja2 markdown templates and badge guard test

### DIFF
--- a/agentic_index_cli/internal/inject_readme.py
+++ b/agentic_index_cli/internal/inject_readme.py
@@ -10,6 +10,8 @@ import pathlib
 import sys
 import traceback
 
+from jinja2 import Template
+
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 README_PATH = ROOT / "README.md"
 DATA_PATH = ROOT / "data" / "top100.md"
@@ -33,6 +35,16 @@ CATEGORY_ICONS = {
 DEFAULT_SORT_FIELD = "score"
 
 DEFAULT_TOP_N = 100
+
+SUMMARY_ROW_TMPL = Template(
+    "| {{ i }} | {{ name }} | {{ desc }} | {{ score }} | "
+    "{{ stars }} | {{ sdelta }} |"
+)
+FULL_ROW_TMPL = Template(
+    "| {{ i }} | {{ name }} | {{ score }} | {{ stars }} | {{ sdelta }} | "
+    "{{ scdelta }} | {{ rec }} | {{ health }} | {{ docs }} | {{ licfr }} | "
+    "{{ eco }} | {{ log2 }} | {{ cat }} |"
+)
 
 
 def _markers(n: int) -> tuple[str, str]:
@@ -201,19 +213,19 @@ def _load_rows(
             name = _clamp_name(name)
         if summary:
             desc = _short_desc(repo.get("description"))
-            row = "| {i} | {name} | {desc} | {score:.2f} | {stars} | {sdelta} |".format(
+            row = SUMMARY_ROW_TMPL.render(
                 i=i,
                 name=name,
                 desc=desc,
-                score=repo["score"],
+                score=f"{repo['score']:.2f}",
                 stars=repo["stars"],
                 sdelta=repo["stars_delta"],
             )
         else:
-            row = "| {i} | {name} | {score:.2f} | {stars} | {sdelta} | {scdelta} | {rec} | {health} | {docs} | {licfr} | {eco} | {log2} | {cat} |".format(
+            row = FULL_ROW_TMPL.render(
                 i=i,
                 name=name,
-                score=repo["score"],
+                score=f"{repo['score']:.2f}",
                 stars=repo["stars"],
                 sdelta=repo["stars_delta"],
                 scdelta=repo["score_delta"],

--- a/agentic_index_cli/internal/rank.py
+++ b/agentic_index_cli/internal/rank.py
@@ -7,12 +7,12 @@ Usage:
 
 import datetime
 import json
-import math
 import os
 import shutil
-import sys
 import urllib.request
 from pathlib import Path
+
+from jinja2 import Template
 
 import lib.quality_metrics  # ensure built-in metrics are registered
 from agentic_index_cli.agentic_index import (
@@ -29,6 +29,10 @@ from .inject_readme import _format_link, _short_desc
 # ─────────────────────────  Scoring & categorisation  ──────────────────────────
 
 SCORE_KEY = "AgenticIndexScore"
+
+SUMMARY_ROW_TMPL = Template(
+    "| {{ i }} | {{ name }} | {{ desc }} | {{ score }} | " "{{ stars }} | {{ delta }} |"
+)
 
 
 def compute_score(repo: dict) -> float:
@@ -226,13 +230,13 @@ def main(json_path: str = "data/repos.json", *, config: dict | None = None) -> N
         return f"{sign}{val}"
 
     rows = [
-        "| {i} | {name} | {desc} | {score:.2f} | {stars} | {sd} |".format(
+        SUMMARY_ROW_TMPL.render(
             i=i,
             name=_format_link(repo["name"], repo.get("html_url")),
             desc=_short_desc(repo.get("description")),
-            score=repo[SCORE_KEY],
+            score=f"{repo[SCORE_KEY]:.2f}",
             stars=repo.get("stars", repo.get("stargazers_count", 0)),
-            sd=fmt(repo["stars_delta"]),
+            delta=fmt(repo["stars_delta"]),
         )
         for i, repo in enumerate(repos[:top_n], start=1)
     ]

--- a/tests/test_generate_badges_guard.py
+++ b/tests/test_generate_badges_guard.py
@@ -1,0 +1,33 @@
+import json
+import urllib.request
+from pathlib import Path
+
+from scripts.generate_badges import main as generate_main
+
+
+def test_generate_badges_once(tmp_path, monkeypatch):
+    data = {"repos": [{"name": "x", "AgenticIndexScore": 1.0}]}
+    json_path = tmp_path / "repos.json"
+    json_path.write_text(json.dumps(data))
+    badges = tmp_path / "badges"
+    badges.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    def fake_open(url):
+        class Resp:
+            def read(self):
+                return b"<svg></svg>"
+
+            def close(self):
+                pass
+
+        return Resp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **kw: fake_open(a[0]))
+
+    generate_main(str(json_path))
+    stamp = Path("state/generate_badges.date")
+    assert stamp.exists()
+    first_mtime = stamp.read_text()
+    generate_main(str(json_path))
+    assert stamp.read_text() == first_mtime


### PR DESCRIPTION
## Summary
- render README tables with Jinja2 templates
- use Jinja2 to build ranking markdown
- test that badge generation runs once per day

## Testing
- `CI_OFFLINE=1 PYTHONPATH="$PWD" pytest -q` *(fails: Missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685261d46e74832a8646ae901c30515c