### PR TITLE
Add JSON caching and benchmark script

### DIFF
--- a/agentic_index_api/main.py
+++ b/agentic_index_api/main.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, HTTPException
+
+from agentic_index_cli.internal.json_utils import load_json
 
 DATA_FILE = Path("data/repos.json")
 HISTORY_DIR = Path("data/history")
@@ -14,8 +15,7 @@ app = FastAPI(title="Agentic Index API")
 
 def _load_repos() -> list[dict[str, Any]]:
     if DATA_FILE.exists():
-        with DATA_FILE.open() as f:
-            data = json.load(f)
+        data = load_json(DATA_FILE, cache=True)
         return data.get("repos", [])
     return []
 
@@ -61,8 +61,7 @@ def get_history(name: str) -> dict[str, Any]:
     points = []
     for path in sorted(HISTORY_DIR.glob("*.json")):
         date = path.stem
-        with path.open() as f:
-            data = json.load(f)
+        data = load_json(path, cache=True)
         for entry in data:
             if not isinstance(entry, dict):
                 continue

--- a/agentic_index_cli/internal/json_utils.py
+++ b/agentic_index_cli/internal/json_utils.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+_cache: Dict[Path, Tuple[float, Any]] = {}
+
+
+def load_json(
+    path: Path,
+    *,
+    cache: bool = False,
+    stream: bool = False,
+) -> Any:
+    """Load JSON from ``path`` with optional caching or streaming."""
+    mtime = path.stat().st_mtime
+    if cache:
+        entry = _cache.get(path)
+        if entry and entry[0] == mtime:
+            return entry[1]
+    data: Any
+    if stream:
+        try:
+            import ijson  # type: ignore
+        except Exception:
+            stream = False
+    if stream:
+        with path.open("rb") as fh:
+            data = ijson.load(fh)
+    else:
+        with path.open() as fh:
+            data = json.load(fh)
+    if cache:
+        _cache[path] = (mtime, data)
+    return data

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,20 @@
+# Performance Tuning
+
+Large `repos.json` files can slow down table generation and diff checks.
+
+## Recommended Limits
+
+- Keep `repos.json` under **10 MB** for best CLI responsiveness.
+- Use the `--top` option of `faststart` to limit rows when testing locally.
+
+## Tips
+
+- Enable caching by passing `use_cache=True` to `load_repos` when repeatedly
+  loading the same file. Cached reads are skipped if the file has not changed.
+- Install `ijson` to parse very large JSON files in streaming mode:
+  ```bash
+  pip install ijson
+  ```
+  Then call `load_repos(..., use_stream=True)`.
+- Run `scripts/benchmark_ops.py` to measure sort and diff times. The script
+  prints a warning when operations exceed built-in baselines.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
       - Conflict Resolution: CONFLICT_RESOLUTION.md
       - Coverage Baseline: coverage_baseline.md
       - Development Setup: DEVELOPMENT.md
+      - Performance Tips: PERFORMANCE.md
   - Methodology: methodology.md
   - CLI Usage: cli.md
   - API Reference:

--- a/scripts/benchmark_ops.py
+++ b/scripts/benchmark_ops.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Benchmark sort and diff operations."""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+REPOS_PATH = Path("data/repos.json")
+BASELINE_SORT = 0.5
+BASELINE_DIFF = 0.2
+THRESHOLD = 1.5
+
+
+def bench_sort() -> float:
+    from agentic_index_cli.validate import load_repos
+
+    repos = load_repos(REPOS_PATH, cache=True, stream=False)
+    start = time.perf_counter()
+    repos.sort(key=lambda r: r.get("AgenticIndexScore", 0), reverse=True)
+    dur = time.perf_counter() - start
+    if dur > BASELINE_SORT * THRESHOLD:
+        print(
+            f"WARNING: sorting took {dur:.3f}s, baseline {BASELINE_SORT:.3f}s",
+            file=sys.stderr,
+        )
+    else:
+        print(f"sort {dur:.3f}s")
+    return dur
+
+
+def bench_diff() -> float:
+    from agentic_index_cli.internal.inject_readme import build_readme, diff
+
+    new_text = build_readme(end_newline=True)
+    start = time.perf_counter()
+    _ = diff(new_text)
+    dur = time.perf_counter() - start
+    if dur > BASELINE_DIFF * THRESHOLD:
+        print(
+            f"WARNING: diff took {dur:.3f}s, baseline {BASELINE_DIFF:.3f}s",
+            file=sys.stderr,
+        )
+    else:
+        print(f"diff {dur:.3f}s")
+    return dur
+
+
+if __name__ == "__main__":
+    bench_sort()
+    bench_diff()


### PR DESCRIPTION
Closes #215

## Summary
- add `load_json` helper with optional cache/streaming
- use `load_json` in API and validation modules
- benchmark diff/sort operations via new script
- document performance tuning
- expose new doc in `mkdocs.yml`

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q` *(fails: Score mismatch; 3 failed, 198 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6852657027e8832a988c23721ac359a5