### PR TITLE
Clean server imports and wrap long lines

### DIFF
--- a/agentic_index_api/server.py
+++ b/agentic_index_api/server.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 from typing import List
 
-from fastapi import FastAPI, Response
-
 """Minimal API server with optional auth."""
 
 import json
-import logging
 import os
 import time
 import uuid
@@ -20,9 +17,12 @@ from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel
 
 from agentic_index_cli import issue_logger
-from agentic_index_cli.internal.rank import SCORE_KEY, compute_score
+from agentic_index_cli.internal.rank import compute_score
 from agentic_index_cli.internal.scrape import scrape
-from agentic_index_cli.logging_config import configure_logging, configure_sentry
+from agentic_index_cli.logging_config import (
+    configure_logging,
+    configure_sentry,
+)
 from agentic_index_cli.validate import save_repos
 
 configure_logging()
@@ -45,10 +45,18 @@ def _load_sync_data() -> List[dict[str, Any]]:
         with SYNC_DATA_PATH.open() as fh:
             data = json.load(fh)
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=400, detail="sync data missing") from exc
+        raise HTTPException(
+            status_code=400,
+            detail="sync data missing",
+        ) from exc
     except json.JSONDecodeError as exc:
-        raise HTTPException(status_code=400, detail="invalid sync data") from exc
-    if not isinstance(data, list) or not all(isinstance(r, dict) for r in data):
+        raise HTTPException(
+            status_code=400,
+            detail="invalid sync data",
+        ) from exc
+    valid_list = isinstance(data, list)
+    valid_items = all(isinstance(r, dict) for r in data)
+    if not valid_list or not valid_items:
         raise HTTPException(status_code=400, detail="invalid sync data")
     return data
 
@@ -174,8 +182,15 @@ async def issue(payload: IssueBody) -> Any:
 
     def _run() -> Any:
         if payload.issue_number is not None:
-            issue_url = f"https://api.github.com/repos/{payload.repo}/issues/{payload.issue_number}"
-            return issue_logger.post_comment(issue_url, payload.body, token=token)
+            issue_url = (
+                f"https://api.github.com/repos/{payload.repo}/issues/"
+                f"{payload.issue_number}"
+            )
+            return issue_logger.post_comment(
+                issue_url,
+                payload.body,
+                token=token,
+            )
         if not payload.title:
             raise HTTPException(status_code=400, detail="title required")
         return issue_logger.create_issue(


### PR DESCRIPTION
## Summary
- tidy imports in agentic_index_api/server.py
- wrap lines to stay under 79 chars
- minor readability tweaks

## Testing
- `black --check agentic_index_api/server.py`
- `isort --check-only agentic_index_api/server.py`
- `flake8 agentic_index_api/server.py`
- `PYTHONPATH="$PWD" pytest -q` *(fails: Score mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68526b3c1b1c832aa6c020fa5548218d