### PR TITLE
Add API reference and README guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,36 @@ Small fluctuations up to ±0.02 are normal between refreshes. See the [📊 Metr
 
 This catalogue is maintained by the Agentic-Index project and is updated regularly (aiming for monthly refreshes) to reflect the rapidly evolving landscape of Agentic-AI.
 
+<a id="-getting-started"></a>
+## 🚀 Getting Started
+
+1. **Install the CLI**
+   ```bash
+   pip install agentic-index-cli
+   ```
+2. **Configure tokens and settings**
+   ```bash
+   cp agentic_index_cli/config.yaml my_config.yml
+   export GITHUB_TOKEN_REPO_STATS=<token>
+   export API_KEY=<optional-api>
+   ```
+   Edit `my_config.yml` to tweak ranking parameters.
+3. **Run the full pipeline**
+   ```bash
+   agentic-index scrape --min-stars 100
+   agentic-index enrich data/repos.json
+   agentic-index faststart --top 100 data/repos.json
+   ```
+   Results appear in `data/` and are injected into `README.md`.
+4. **Browse the docs** – The full API reference lives in [`docs/`](docs/index.md).
+
 -----
 
 ## TOC
 
 * [✨ Why Agentic Index is Different](#-why-agentic-index-is-different)
 * [⚡ Installation & Quick-start](#-installation--quick-start)
+* [🚀 Getting Started](#-getting-started)
 * [🏆 The Agentic-Index Top 100: AI Agent Repositories](#-the-agentic-index-top-100-ai-agent-repositories)
   * [💎 Honourable Mentions / Niche & Novel Gems](HONOURABLE.md)
     * [🔬 Our Methodology & Scoring Explained](#our-methodology--scoring-explained)
@@ -206,12 +230,7 @@ Quick guide to our categories (and the icons you'll see in the table):
 <a id="-explore-by-category"></a>
 ## 📚 Explore by Category
 <!-- CATEGORY:START -->
-- 🛠️ [DevTools](README_DevTools.md)
-- 🎯 [Domain-Specific](README_Domain-Specific.md)
-- 🧪 [Experimental](README_Experimental.md)
-- 🌐 [General-purpose](README_General-purpose.md)
-- 🤖 [Multi-Agent](README_Multi-Agent.md)
-- 📚 [RAG-centric](README_RAG-centric.md)
+
 <!-- CATEGORY:END -->
 -----
 

--- a/docs/reference/agentic_index_api.md
+++ b/docs/reference/agentic_index_api.md
@@ -1,0 +1,4 @@
+::: agentic_index_api
+handler: python
+rendering:
+  show_source: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,3 +17,4 @@ nav:
   - CLI Usage: cli.md
   - API Reference:
       - agentic_index_cli: reference/agentic_index_cli.md
+      - agentic_index_api: reference/agentic_index_api.md

--- a/tests/fixtures/README_fixture.md
+++ b/tests/fixtures/README_fixture.md
@@ -33,12 +33,36 @@ Small fluctuations up to ±0.02 are normal between refreshes. See the [📊 Metr
 
 This catalogue is maintained by the Agentic-Index project and is updated regularly (aiming for monthly refreshes) to reflect the rapidly evolving landscape of Agentic-AI.
 
+<a id="-getting-started"></a>
+## 🚀 Getting Started
+
+1. **Install the CLI**
+   ```bash
+   pip install agentic-index-cli
+   ```
+2. **Configure tokens and settings**
+   ```bash
+   cp agentic_index_cli/config.yaml my_config.yml
+   export GITHUB_TOKEN_REPO_STATS=<token>
+   export API_KEY=<optional-api>
+   ```
+   Edit `my_config.yml` to tweak ranking parameters.
+3. **Run the full pipeline**
+   ```bash
+   agentic-index scrape --min-stars 100
+   agentic-index enrich data/repos.json
+   agentic-index faststart --top 100 data/repos.json
+   ```
+   Results appear in `data/` and are injected into `README.md`.
+4. **Browse the docs** – The full API reference lives in [`docs/`](docs/index.md).
+
 -----
 
 ## TOC
 
 * [✨ Why Agentic Index is Different](#-why-agentic-index-is-different)
 * [⚡ Installation & Quick-start](#-installation--quick-start)
+* [🚀 Getting Started](#-getting-started)
 * [🏆 The Agentic-Index Top 100: AI Agent Repositories](#-the-agentic-index-top-100-ai-agent-repositories)
   * [💎 Honourable Mentions / Niche & Novel Gems](HONOURABLE.md)
     * [🔬 Our Methodology & Scoring Explained](#our-methodology--scoring-explained)


### PR DESCRIPTION
## Summary
- generate API docs with mkdocstrings
- document installation, configuration, and pipeline usage
- link generated docs in README

## Testing
- `pre-commit run --files README.md mkdocs.yml docs/reference/agentic_index_api.md tests/fixtures/README_fixture.md`
- `mkdocs build`
- `PYTHONPATH="$PWD" pytest -q` *(fails: 25 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68526df87a6c832a9fbbae1507fa83fc