### PR TITLE
Add metrics monitor script

### DIFF
--- a/.github/workflows/metrics-monitor.yml
+++ b/.github/workflows/metrics-monitor.yml
@@ -1,0 +1,30 @@
+name: Metrics Monitor
+
+on:
+  schedule:
+    - cron: '15 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Run check
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.METRICS_SLACK_WEBHOOK }}
+          SMTP_SERVER: ${{ secrets.SMTP_SERVER }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          ALERT_EMAIL: ${{ secrets.ALERT_EMAIL }}
+          FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/check_metrics.py

--- a/docs/METRICS_ALERTS.md
+++ b/docs/METRICS_ALERTS.md
@@ -1,0 +1,23 @@
+# Metrics Alerting
+
+This repository includes a daily monitor that checks GitHub statistics for all tracked projects. If star counts drop or releases go stale, notifications can be sent to Slack or via email.
+
+## Configuration
+
+The checker reads `data/repos.json` by default. Adjust behaviour through environment variables:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `METRICS_FILE` | Path to the repo data JSON file | `data/repos.json` |
+| `STAR_DROP_THRESHOLD` | Stars must not fall below this many from the recorded value | `1` |
+| `RELEASE_AGE_THRESHOLD` | Allowed increase in days since last release | `30` |
+| `SLACK_WEBHOOK_URL` | If set, alerts are POSTed to this Slack webhook | – |
+| `SMTP_SERVER` | SMTP server for email alerts | – |
+| `SMTP_PORT` | Port for SMTP server | `25` |
+| `SMTP_USER`/`SMTP_PASS` | Credentials for SMTP authentication | – |
+| `ALERT_EMAIL` | Destination email address | – |
+| `FROM_EMAIL` | Sender address for email alerts | value of `ALERT_EMAIL` |
+
+## Customisation
+
+Set the thresholds or webhook variables as secrets in GitHub Actions or in your local environment. When the scheduled workflow runs, any metrics that fall outside the configured ranges trigger a Slack message or an email summarising the issues.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
       - Coverage Baseline: coverage_baseline.md
       - Development Setup: DEVELOPMENT.md
       - Performance Tips: PERFORMANCE.md
+      - Metrics Alerts: METRICS_ALERTS.md
   - Methodology: methodology.md
   - CLI Usage: cli.md
   - API Reference:

--- a/scripts/check_metrics.py
+++ b/scripts/check_metrics.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Monitor GitHub metrics and alert on unexpected changes."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import requests
+
+STAR_DROP_THRESHOLD = int(os.getenv("STAR_DROP_THRESHOLD", "1"))
+RELEASE_AGE_THRESHOLD = int(os.getenv("RELEASE_AGE_THRESHOLD", "30"))
+
+
+def _headers() -> Dict[str, str]:
+    token = os.getenv("GITHUB_TOKEN")
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+    return headers
+
+
+def fetch_repo_data(full_name: str) -> Dict[str, int | None]:
+    """Return current star count and release age for ``full_name``."""
+    resp = requests.get(
+        f"https://api.github.com/repos/{full_name}", headers=_headers(), timeout=10
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    stars = int(data.get("stargazers_count", 0))
+
+    rel_resp = requests.get(
+        f"https://api.github.com/repos/{full_name}/releases/latest",
+        headers=_headers(),
+        timeout=10,
+    )
+    release_age = None
+    if rel_resp.status_code == 200:
+        ts = rel_resp.json().get("published_at")
+        if ts:
+            try:
+                dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+                release_age = (
+                    datetime.now(timezone.utc) - dt.replace(tzinfo=timezone.utc)
+                ).days
+            except Exception:
+                release_age = None
+    return {"stars": stars, "release_age": release_age}
+
+
+def slack_alert(message: str) -> None:
+    url = os.getenv("SLACK_WEBHOOK_URL")
+    if not url:
+        return
+    try:
+        requests.post(url, json={"text": message}, timeout=10)
+    except Exception:
+        pass
+
+
+def email_alert(subject: str, message: str) -> None:
+    import smtplib
+    from email.message import EmailMessage
+
+    to_addr = os.getenv("ALERT_EMAIL")
+    server = os.getenv("SMTP_SERVER")
+    if not (to_addr and server):
+        return
+    from_addr = os.getenv("FROM_EMAIL", to_addr)
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = to_addr
+    msg.set_content(message)
+    try:
+        port = int(os.getenv("SMTP_PORT", "25"))
+        user = os.getenv("SMTP_USER")
+        password = os.getenv("SMTP_PASS")
+        with smtplib.SMTP(server, port) as smtp:
+            if user:
+                smtp.starttls()
+                smtp.login(user, password or "")
+            smtp.send_message(msg)
+    except Exception:
+        pass
+
+
+def load_repos(path: str) -> Iterable[dict]:
+    data = json.loads(Path(path).read_text())
+    return data.get("repos", data)
+
+
+def check_repo(repo: dict) -> List[str]:
+    actual = fetch_repo_data(repo["full_name"])
+    messages = []
+    expected_stars = repo.get("stargazers_count", repo.get("stars", 0))
+    if actual["stars"] < expected_stars - STAR_DROP_THRESHOLD:
+        messages.append(
+            f"{repo['full_name']} stars {expected_stars}->{actual['stars']}"
+        )
+    exp_age = repo.get("release_age")
+    act_age = actual.get("release_age")
+    if exp_age is not None and act_age is not None:
+        if act_age > exp_age + RELEASE_AGE_THRESHOLD:
+            messages.append(f"{repo['full_name']} release age {exp_age}->{act_age}d")
+    return messages
+
+
+def main(path: str = "data/repos.json") -> int:
+    repos = load_repos(path)
+    alerts: List[str] = []
+    for repo in repos:
+        alerts.extend(check_repo(repo))
+    if alerts:
+        message = "\n".join(alerts)
+        slack_alert(message)
+        email_alert("Agentic Index metrics alert", message)
+        print(message)
+        return 1
+    print("All metrics within expected ranges")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(os.getenv("METRICS_FILE", "data/repos.json")))

--- a/tests/test_metrics_monitor.py
+++ b/tests/test_metrics_monitor.py
@@ -1,0 +1,29 @@
+import importlib.util
+import json
+from pathlib import Path
+from unittest import mock
+
+spec = importlib.util.spec_from_file_location(
+    "monitor", Path("scripts/check_metrics.py")
+)
+monitor = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(monitor)
+
+
+def test_alert_on_drop(monkeypatch, tmp_path):
+    repo = {
+        "full_name": "owner/repo",
+        "stargazers_count": 10,
+        "release_age": 5,
+    }
+    data = {"repos": [repo]}
+    path = tmp_path / "repos.json"
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr(
+        monitor, "fetch_repo_data", lambda name: {"stars": 5, "release_age": 40}
+    )
+    alerts = []
+    monkeypatch.setattr(monitor, "slack_alert", lambda msg: alerts.append(msg))
+    monkeypatch.setattr(monitor, "email_alert", lambda subj, msg: alerts.append(msg))
+    monitor.main(str(path))
+    assert alerts


### PR DESCRIPTION
## Summary
- monitor repo metrics daily and post Slack/email alerts
- add scheduled workflow to run the checker
- document how to customize metric alerts
- test monitoring logic

## Testing
- `pytest tests/test_metrics_monitor.py -q`
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q` *(fails: actionlint missing)*

------
https://chatgpt.com/codex/tasks/task_e_68526e016e64832aa91765583a30cbf0