### PR TITLE
Add dry-run tests and document Python env parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,16 @@ python scripts/inject_readme.py --force
 
 This can be handy after metric tweaks that don't change rankings but should refresh the snapshot.
 
+### 🔍 Preview changes with `--dry-run`
+
+Use `--dry-run` to print a unified diff without modifying `README.md`:
+
+```bash
+python scripts/inject_readme.py --dry-run
+```
+
+This lets you verify upcoming updates locally or in CI.
+
 -----
 
 <a id="-how-to-contribute"></a>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -23,10 +23,11 @@ Run the helper script to prepare your environment:
 source scripts/setup-env.sh
 ```
 
-The script verifies Python ≥3.10, installs required system packages, creates a
-virtual environment with all dependencies, exports `PYTHONPATH`, and installs
-pre-commit hooks. It also loads any variables in a `.env` file or prompts for
-missing values such as API keys.
+The script verifies Python **3.11** or newer, installs required system packages,
+creates a virtual environment with the pinned dependencies from
+`requirements.lock`, exports `PYTHONPATH`, and installs pre-commit hooks. It also
+loads any variables in a `.env` file or prompts for missing values such as API
+keys.
 
 ## Troubleshooting FAQ
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -30,6 +30,13 @@ Use the helper script to install all runtime and development dependencies and se
 bash scripts/agent-setup.sh
 ```
 This installs `pre-commit` and performs a `pip install -e .` under the hood.
+CI and production run on **Python 3.11** with dependencies pinned in
+`requirements.lock`. Use the same version locally to avoid surprises:
+```bash
+pyenv install 3.11.12  # if needed
+pyenv local 3.11.12
+pip install -r requirements.lock
+```
 
 ## Pre-commit Hooks
 Activate hooks so formatting and lint checks run before each commit. The hooks

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -13,10 +13,11 @@ fi
 PY_VER=$(python3 -c 'import sys; print("{}.{}.{}".format(*sys.version_info[:3]))')
 if ! python3 - <<'PY'
 import sys
-raise SystemExit(0 if sys.version_info >= (3,10) else 1)
+
+raise SystemExit(0 if sys.version_info >= (3,11) else 1)
 PY
 then
-  echo "Python 3.10 or newer required. Found $PY_VER"
+  echo "Python 3.11 or newer required. Found $PY_VER"
   return 1
 fi
 
@@ -38,7 +39,7 @@ fi
 source .venv/bin/activate
 
 pip install --upgrade pip
-pip install -r requirements.txt
+pip install -r requirements.lock
 pip install -e .
 pip install black isort flake8 mypy bandit pre-commit
 pre-commit install --install-hooks
@@ -62,6 +63,7 @@ fi
 
 python - <<'PY'
 import sys
+
 try:
     import agentic_index_cli
 except Exception as e:

--- a/tests/fixtures/README_fixture.md
+++ b/tests/fixtures/README_fixture.md
@@ -119,56 +119,56 @@ The definitive list of Agentic-AI repositories, ranked by the Agentic Index Scor
 <!-- TOP50:START -->
 | Rank | Repo | Description | Score | Stars | Δ Stars |
 |-----:|------|-------------|------:|------:|--------:|
-| 1 | [dify](https://github.com/langgenius/dify) | Production-ready platform for agentic workflow development. | 6.08 | 103135 |  |
-| 2 | [langflow](https://github.com/langflow-ai/langflow) | Langflow is a powerful tool for building and deploying AI-powered agents and workflows. | 5.96 | 73030 |  |
-| 3 | [browser-use](https://github.com/browser-use/browser-use) | 🌐 Make websites accessible for AI agents. Automate tasks online with ease. | 5.88 | 63085 |  |
-| 4 | [OpenHands](https://github.com/All-Hands-AI/OpenHands) | 🙌 OpenHands: Code Less, Make More | 5.84 | 57980 |  |
-| 5 | [lobe-chat](https://github.com/lobehub/lobe-chat) | 🤯 Lobe Chat - an open-source, modern-design AI chat framework. Supports Multi AI Providers( OpenAI / Claude 4 / Gemini / Ollama / DeepSeek / Qwen),... | 5.83 | 62452 |  |
-| 6 | [MetaGPT](https://github.com/FoundationAgents/MetaGPT) | 🌟 The Multi-Agent Framework: First AI Software Company, Towards Natural Language Programming | 5.82 | 56381 |  |
-| 7 | [ragflow](https://github.com/infiniflow/ragflow) | RAGFlow is an open-source RAG (Retrieval-Augmented Generation) engine based on deep document understanding. | 5.81 | 55032 |  |
-| 8 | [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) | Unified Efficient Fine-Tuning of 100+ LLMs & VLMs (ACL 2024) | 5.79 | 52214 |  |
-| 9 | [system-prompts-and-models...](https://github.com/x1xhlol/system-prompts-and-models-of-ai-tools) | FULL v0, Cursor, Manus, Same.dev, Lovable, Devin, Replit Agent, Windsurf Agent, VSCode Agent, Dia Browser & Trae AI (And other Open Sourced) System... | 5.78 | 57188 |  |
-| 10 | [cline](https://github.com/cline/cline) | Autonomous coding agent right in your IDE, capable of creating/editing files, executing commands, using the browser, and more with your permission ... | 5.72 | 45640 |  |
-| 11 | [anything-llm](https://github.com/Mintplex-Labs/anything-llm) | The all-in-one Desktop & Docker AI application with built-in RAG, AI agents, No-code agent builder, MCP compatibility,  and more. | 5.71 | 45276 |  |
-| 12 | [llama_index](https://github.com/run-llama/llama_index) | LlamaIndex is the leading framework for building LLM-powered agents over your data. | 5.68 | 42328 |  |
-| 13 | [autogen](https://github.com/microsoft/autogen) | A programming framework for agentic AI 🤖 PyPi: autogen-agentchat Discord: https://aka.ms/autogen-discord Office Hour: https://aka.ms/autogen-office... | 5.67 | 45934 |  |
-| 14 | [awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps) | Collection of awesome LLM apps with AI Agents and RAG using OpenAI, Anthropic, Gemini and opensource models. | 5.63 | 38434 |  |
-| 15 | [Flowise](https://github.com/FlowiseAI/Flowise) | Build AI Agents, Visually | 5.60 | 39990 |  |
-| 16 | [mem0](https://github.com/mem0ai/mem0) | Memory for AI Agents; Announcing OpenMemory MCP - local and secure memory management. | 5.57 | 34409 |  |
-| 17 | [ChatTTS](https://github.com/2noise/ChatTTS) | A generative speech model for daily dialogue. | 5.56 | 36777 |  |
-| 18 | [Langchain-Chatchat](https://github.com/chatchat-space/Langchain-Chatchat) | Langchain-Chatchat（原Langchain-ChatGLM）基于 Langchain 与 ChatGLM, Qwen 与 Llama 等语言模型的 RAG 与 Agent 应用 / Langchain-Chatchat (formerly langchain-ChatGLM),... | 5.56 | 35279 |  |
-| 19 | [crewAI](https://github.com/crewAIInc/crewAI) | Framework for orchestrating role-playing, autonomous AI agents. By fostering collaborative intelligence, CrewAI empowers agents to work together se... | 5.55 | 32869 |  |
-| 20 | [AgentGPT](https://github.com/reworkd/AgentGPT) | 🤖 Assemble, configure, and deploy autonomous AI Agents in your browser. | 5.51 | 34319 |  |
-| 21 | [agno](https://github.com/agno-agi/agno) | Full-stack framework for building Multi-Agent Systems with memory, knowledge and reasoning. | 5.47 | 28227 |  |
-| 22 | [khoj](https://github.com/khoj-ai/khoj) | Your AI second brain. Self-hostable. Get answers from the web or your docs. Build custom agents, schedule automations, do deep research. Turn any o... | 5.46 | 30318 |  |
-| 23 | [ChatDev](https://github.com/OpenBMB/ChatDev) | Create Customized Software using Natural Language Idea (through LLM-powered Multi-Agent Collaboration) | 5.45 | 27021 |  |
-| 24 | [LibreChat](https://github.com/danny-avila/LibreChat) | Enhanced ChatGPT Clone: Features Agents, DeepSeek, Anthropic, AWS, OpenAI, Assistants API, Azure, Groq, o1, GPT-4o, Mistral, OpenRouter, Vertex AI,... | 5.45 | 26727 |  |
-| 25 | [ai-agents-for-beginners](https://github.com/microsoft/ai-agents-for-beginners) | 11 Lessons to Get Started Building AI Agents | 5.43 | 26018 |  |
-| 26 | [cherry-studio](https://github.com/CherryHQ/cherry-studio) | 🍒 Cherry Studio is a desktop client that supports for multiple LLM providers. | 5.43 | 28392 |  |
-| 27 | [Jobs_Applier_AI_Agent_AIHawk](https://github.com/feder-cr/Jobs_Applier_AI_Agent_AIHawk) | AIHawk aims to easy job hunt process by automating the job application process. Utilizing artificial intelligence, it enables users to apply for mu... | 5.43 | 28304 |  |
-| 28 | [qlib](https://github.com/microsoft/qlib) | Qlib is an AI-oriented Quant investment platform that aims to use AI tech to empower Quant Research, from exploring ideas to implementing productio... | 5.42 | 25080 |  |
-| 29 | [composio](https://github.com/ComposioHQ/composio) | Composio equips your AI agents & LLMs with 100+ high-quality integrations via function calling | 5.37 | 25493 |  |
-| 30 | [FastGPT](https://github.com/labring/FastGPT) | FastGPT is a knowledge-based platform built on the LLMs, offers a comprehensive suite of out-of-the-box capabilities such as data processing, RAG r... | 5.36 | 24714 |  |
-| 31 | [gpt-researcher](https://github.com/assafelovic/gpt-researcher) | LLM based autonomous agent that conducts deep local and web research on any topic and generates a long report with citations. | 5.35 | 21855 |  |
-| 32 | [CopilotKit](https://github.com/CopilotKit/CopilotKit) | React UI + elegant infrastructure for AI Copilots, AI chatbots, and in-app AI agents. The Agentic last-mile 🪁 | 5.33 | 21149 |  |
-| 33 | [haystack](https://github.com/deepset-ai/haystack) | AI orchestration framework to build customizable, production-ready LLM applications. Connect components (models, vector DBs, file converters) to pi... | 5.33 | 21141 |  |
-| 34 | [swarm](https://github.com/openai/swarm) | Educational framework exploring ergonomic, lightweight multi-agent orchestration. Managed by OpenAI Solution team. | 5.26 | 19917 |  |
-| 35 | [agentic](https://github.com/transitive-bullshit/agentic) | AI agent stdlib that works with any LLM and TypeScript AI SDK. | 5.24 | 17632 |  |
-| 36 | [vanna](https://github.com/vanna-ai/vanna) | 🤖 Chat with your SQL database 📊. Accurate Text-to-SQL Generation via LLMs using RAG 🔄. | 5.23 | 18102 |  |
-| 37 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | AI Native Data App Development framework with AWEL(Agentic Workflow Expression Language) and Agents | 5.21 | 16757 |  |
-| 38 | [deep-research](https://github.com/dzhng/deep-research) | An AI-powered research assistant that performs iterative, deep research on any topic by combining search engines, web scraping, and large language ... | 5.21 | 16627 |  |
-| 39 | [letta](https://github.com/letta-ai/letta) | Letta (formerly MemGPT) is the stateful agents framework with memory, reasoning, and context management. | 5.21 | 16841 |  |
-| 40 | [agenticSeek](https://github.com/Fosowl/agenticSeek) | Fully Local Manus AI. No APIs, No $200 monthly bills. Enjoy an autonomous agent that thinks, browses the web, and code for the sole cost of electri... | 5.20 | 18115 |  |
-| 41 | [SWE-agent](https://github.com/SWE-agent/SWE-agent) | SWE-agent takes a GitHub issue and tries to automatically fix it, using your LM of choice. It can also be employed for offensive cybersecurity or c... | 5.20 | 16282 |  |
-| 42 | [eliza](https://github.com/elizaOS/eliza) | Autonomous agents for everyone | 5.19 | 16065 |  |
-| 43 | [RagaAI-Catalyst](https://github.com/raga-ai-hub/RagaAI-Catalyst) | Python SDK for Agent AI Observability, Monitoring and Evaluation Framework. Includes features like agent, llm and tools tracing, debugging multi-ag... | 5.19 | 16188 |  |
-| 44 | [DocsGPT](https://github.com/arc53/DocsGPT) | DocsGPT is an open-source genAI tool that helps users get reliable answers from knowledge source, while avoiding hallucinations. It enables private... | 5.18 | 15708 |  |
-| 45 | [awesome-ai-agents](https://github.com/e2b-dev/awesome-ai-agents) | A list of AI autonomous agents | 5.17 | 18563 |  |
-| 46 | [devika](https://github.com/stitionai/devika) | Devika is an Agentic AI Software Engineer that can understand high-level human instructions, break them down into steps, research relevant informat... | 5.14 | 19330 |  |
-| 47 | [goose](https://github.com/block/goose) | an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM | 5.14 | 14558 |  |
-| 48 | [suna](https://github.com/kortix-ai/suna) | Suna - Open Source Generalist AI Agent | 5.13 | 14367 |  |
-| 49 | [SuperAGI](https://github.com/TransformerOptimus/SuperAGI) | <⚡️> SuperAGI - A dev-first open source autonomous AI agent framework. Enabling developers to build, manage & run useful autonomous agents quickly ... | 5.13 | 16412 |  |
-| 50 | [ai-pdf-chatbot-langchain](https://github.com/mayooear/ai-pdf-chatbot-langchain) | AI PDF chatbot agent built with LangChain & LangGraph  | 5.12 | 15572 |  |
+| 1 | [dify](https://github.com/langgenius/dify) | Production-ready platform for agentic workflow development. | 5.28 | 103268 |  |
+| 2 | [langflow](https://github.com/langflow-ai/langflow) | Langflow is a powerful tool for building and deploying AI-powered agents and workflows. | 5.17 | 73776 |  |
+| 3 | [browser-use](https://github.com/browser-use/browser-use) | 🌐 Make websites accessible for AI agents. Automate tasks online with ease. | 5.10 | 63197 |  |
+| 4 | [OpenHands](https://github.com/All-Hands-AI/OpenHands) | 🙌 OpenHands: Code Less, Make More | 5.07 | 58086 |  |
+| 5 | [lobe-chat](https://github.com/lobehub/lobe-chat) | 🤯 Lobe Chat - an open-source, modern-design AI chat framework. Supports Multi AI Providers( OpenAI / Claude 4 / Gemini / Ollama / DeepSeek / Qwen),... | 5.06 | 62457 |  |
+| 6 | [MetaGPT](https://github.com/FoundationAgents/MetaGPT) | 🌟 The Multi-Agent Framework: First AI Software Company, Towards Natural Language Programming | 5.06 | 56406 |  |
+| 7 | [ragflow](https://github.com/infiniflow/ragflow) | RAGFlow is an open-source RAG (Retrieval-Augmented Generation) engine based on deep document understanding. | 5.04 | 55104 |  |
+| 8 | [system-prompts-and-models...](https://github.com/x1xhlol/system-prompts-and-models-of-ai-tools) | FULL v0, Cursor, Manus, Same.dev, Lovable, Devin, Replit Agent, Windsurf Agent, VSCode Agent, Dia Browser & Trae AI (And other Open Sourced) System... | 5.03 | 57495 |  |
+| 9 | [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) | Unified Efficient Fine-Tuning of 100+ LLMs & VLMs (ACL 2024) | 5.02 | 52281 |  |
+| 10 | [anything-llm](https://github.com/Mintplex-Labs/anything-llm) | The all-in-one Desktop & Docker AI application with built-in RAG, AI agents, No-code agent builder, MCP compatibility,  and more. | 4.96 | 45309 |  |
+| 11 | [cline](https://github.com/cline/cline) | Autonomous coding agent right in your IDE, capable of creating/editing files, executing commands, using the browser, and more with your permission ... | 4.96 | 45704 |  |
+| 12 | [autogen](https://github.com/microsoft/autogen) | A programming framework for agentic AI 🤖 PyPi: autogen-agentchat Discord: https://aka.ms/autogen-discord Office Hour: https://aka.ms/autogen-office... | 4.93 | 45993 |  |
+| 13 | [llama_index](https://github.com/run-llama/llama_index) | LlamaIndex is the leading framework for building LLM-powered agents over your data. | 4.93 | 42355 |  |
+| 14 | [awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps) | Collection of awesome LLM apps with AI Agents and RAG using OpenAI, Anthropic, Gemini and opensource models. | 4.92 | 41125 |  |
+| 15 | [Flowise](https://github.com/FlowiseAI/Flowise) | Build AI Agents, Visually | 4.87 | 40065 |  |
+| 16 | [ChatTTS](https://github.com/2noise/ChatTTS) | A generative speech model for daily dialogue. | 4.84 | 36799 |  |
+| 17 | [mem0](https://github.com/mem0ai/mem0) | Memory for AI Agents; Announcing OpenMemory MCP - local and secure memory management. | 4.84 | 34513 |  |
+| 18 | [crewAI](https://github.com/crewAIInc/crewAI) | Framework for orchestrating role-playing, autonomous AI agents. By fostering collaborative intelligence, CrewAI empowers agents to work together se... | 4.82 | 32933 |  |
+| 19 | [Langchain-Chatchat](https://github.com/chatchat-space/Langchain-Chatchat) | Langchain-Chatchat（原Langchain-ChatGLM）基于 Langchain 与 ChatGLM, Qwen 与 Llama 等语言模型的 RAG 与 Agent 应用 / Langchain-Chatchat (formerly langchain-ChatGLM),... | 4.81 | 35287 |  |
+| 20 | [AgentGPT](https://github.com/reworkd/AgentGPT) | 🤖 Assemble, configure, and deploy autonomous AI Agents in your browser. | 4.79 | 34323 |  |
+| 21 | [agno](https://github.com/agno-agi/agno) | Full-stack framework for building Multi-Agent Systems with memory, knowledge and reasoning. | 4.76 | 28280 |  |
+| 22 | [khoj](https://github.com/khoj-ai/khoj) | Your AI second brain. Self-hostable. Get answers from the web or your docs. Build custom agents, schedule automations, do deep research. Turn any o... | 4.75 | 30327 |  |
+| 23 | [ChatDev](https://github.com/OpenBMB/ChatDev) | Create Customized Software using Natural Language Idea (through LLM-powered Multi-Agent Collaboration) | 4.74 | 27024 |  |
+| 24 | [ai-agents-for-beginners](https://github.com/microsoft/ai-agents-for-beginners) | 11 Lessons to Get Started Building AI Agents | 4.73 | 26615 |  |
+| 25 | [LibreChat](https://github.com/danny-avila/LibreChat) | Enhanced ChatGPT Clone: Features Agents, DeepSeek, Anthropic, AWS, OpenAI, Assistants API, Azure, Groq, o1, GPT-4o, Mistral, OpenRouter, Vertex AI,... | 4.73 | 26789 |  |
+| 26 | [cherry-studio](https://github.com/CherryHQ/cherry-studio) | 🍒 Cherry Studio is a desktop client that supports for multiple LLM providers. | 4.72 | 28444 |  |
+| 27 | [Jobs_Applier_AI_Agent_AIHawk](https://github.com/feder-cr/Jobs_Applier_AI_Agent_AIHawk) | AIHawk aims to easy job hunt process by automating the job application process. Utilizing artificial intelligence, it enables users to apply for mu... | 4.72 | 28310 |  |
+| 28 | [qlib](https://github.com/microsoft/qlib) | Qlib is an AI-oriented Quant investment platform that aims to use AI tech to empower Quant Research, from exploring ideas to implementing productio... | 4.71 | 25192 |  |
+| 29 | [composio](https://github.com/ComposioHQ/composio) | Composio equips your AI agents & LLMs with 100+ high-quality integrations via function calling | 4.68 | 25499 |  |
+| 30 | [FastGPT](https://github.com/labring/FastGPT) | FastGPT is a knowledge-based platform built on the LLMs, offers a comprehensive suite of out-of-the-box capabilities such as data processing, RAG r... | 4.66 | 24718 |  |
+| 31 | [gpt-researcher](https://github.com/assafelovic/gpt-researcher) | LLM based autonomous agent that conducts deep local and web research on any topic and generates a long report with citations. | 4.65 | 21875 |  |
+| 32 | [CopilotKit](https://github.com/CopilotKit/CopilotKit) | React UI + elegant infrastructure for AI Copilots, AI chatbots, and in-app AI agents. The Agentic last-mile 🪁 | 4.63 | 21205 |  |
+| 33 | [haystack](https://github.com/deepset-ai/haystack) | AI orchestration framework to build customizable, production-ready LLM applications. Connect components (models, vector DBs, file converters) to pi... | 4.63 | 21154 |  |
+| 34 | [swarm](https://github.com/openai/swarm) | Educational framework exploring ergonomic, lightweight multi-agent orchestration. Managed by OpenAI Solution team. | 4.56 | 19920 |  |
+| 35 | [agentic](https://github.com/transitive-bullshit/agentic) | AI agent stdlib that works with any LLM and TypeScript AI SDK. | 4.55 | 17639 |  |
+| 36 | [vanna](https://github.com/vanna-ai/vanna) | 🤖 Chat with your SQL database 📊. Accurate Text-to-SQL Generation via LLMs using RAG 🔄. | 4.54 | 18127 |  |
+| 37 | [agenticSeek](https://github.com/Fosowl/agenticSeek) | Fully Local Manus AI. No APIs, No $200 monthly bills. Enjoy an autonomous agent that thinks, browses the web, and code for the sole cost of electri... | 4.53 | 18268 |  |
+| 38 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | AI Native Data App Development framework with AWEL(Agentic Workflow Expression Language) and Agents | 4.53 | 16764 |  |
+| 39 | [deep-research](https://github.com/dzhng/deep-research) | An AI-powered research assistant that performs iterative, deep research on any topic by combining search engines, web scraping, and large language ... | 4.53 | 16638 |  |
+| 40 | [letta](https://github.com/letta-ai/letta) | Letta (formerly MemGPT) is the stateful agents framework with memory, reasoning, and context management. | 4.53 | 16861 |  |
+| 41 | [SWE-agent](https://github.com/SWE-agent/SWE-agent) | SWE-agent takes a GitHub issue and tries to automatically fix it, using your LM of choice. It can also be employed for offensive cybersecurity or c... | 4.52 | 16305 |  |
+| 42 | [eliza](https://github.com/elizaOS/eliza) | Autonomous agents for everyone | 4.51 | 16078 |  |
+| 43 | [RagaAI-Catalyst](https://github.com/raga-ai-hub/RagaAI-Catalyst) | Python SDK for Agent AI Observability, Monitoring and Evaluation Framework. Includes features like agent, llm and tools tracing, debugging multi-ag... | 4.51 | 16193 |  |
+| 44 | [DocsGPT](https://github.com/arc53/DocsGPT) | DocsGPT is an open-source genAI tool that helps users get reliable answers from knowledge source, while avoiding hallucinations. It enables private... | 4.50 | 15708 |  |
+| 45 | [awesome-ai-agents](https://github.com/e2b-dev/awesome-ai-agents) | A list of AI autonomous agents | 4.48 | 18587 |  |
+| 46 | [goose](https://github.com/block/goose) | an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM | 4.47 | 14627 |  |
+| 47 | [activepieces](https://github.com/activepieces/activepieces) | AI Agents & MCPs & AI Workflow Automation • (280+ MCP servers for AI agents) • AI Automation / AI Agent with MCPs • AI Workflows & AI Agents • MCPs... | 4.46 | 15291 |  |
+| 48 | [suna](https://github.com/kortix-ai/suna) | Suna - Open Source Generalist AI Agent | 4.46 | 14425 |  |
+| 49 | [ai](https://github.com/vercel/ai) | The AI Toolkit for TypeScript. From the creators of Next.js, the AI SDK is a free open-source library for building AI-powered applications and agents  | 4.45 | 14955 |  |
+| 50 | [botpress](https://github.com/botpress/botpress) | The open-source hub to build & deploy GPT/LLM Agents ⚡️ | 4.45 | 13805 |  |
 <!-- TOP50:END -->
 *➡️ Dig into how these scores are cooked up in our [Methodology section](#our-methodology--scoring-explained) and the [full recipe in /docs/methodology.md](./docs/methodology.md).*
 
@@ -342,6 +342,16 @@ python scripts/inject_readme.py --force
 
 This can be handy after metric tweaks that don't change rankings but should refresh the snapshot.
 
+### 🔍 Preview changes with `--dry-run`
+
+Use `--dry-run` to print a unified diff without modifying `README.md`:
+
+```bash
+python scripts/inject_readme.py --dry-run
+```
+
+This lets you verify upcoming updates locally or in CI.
+
 -----
 
 <a id="-how-to-contribute"></a>
@@ -385,4 +395,3 @@ Any scripts or code for analysis and generation (e.g., in `/scripts`, if we add 
 
 
 ![Last Sync](badges/last_sync.svg) ![Top Repo](badges/top_repo.svg) ![Repo Count](badges/repo_count.svg)
-

--- a/tests/test_inject_cli_script.py
+++ b/tests/test_inject_cli_script.py
@@ -55,3 +55,21 @@ def test_inject_script_all_categories(monkeypatch):
     sys.argv = [str(script), "--all-categories"]
     runpy.run_path(script, run_name="__main__")
     assert called != {}
+
+
+def test_inject_script_dry_run(monkeypatch):
+    called = {}
+
+    def fake_main(**kwargs):
+        called.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "agentic_index_cli.internal.inject_readme.main",
+        fake_main,
+    )
+    script = Path(__file__).resolve().parents[1] / "scripts" / "inject_readme.py"
+    sys.argv = [str(script), "--dry-run"]
+    runpy.run_path(script, run_name="__main__")
+    assert called["check"] is True
+    assert called["write"] is False


### PR DESCRIPTION
## Summary
- ensure inject_readme.py forwards `--dry-run`
- update README with dry-run example
- note Python 3.11 and pinned deps in dev docs
- enforce Python version and lockfile in setup script
- refresh README fixture for tests

Closes #GH-DEMO-1

## Testing
- `CI_OFFLINE=1 PYTHONPATH="$PWD" pytest -q`
- `black --check . && isort --check-only .`


------
https://chatgpt.com/codex/tasks/task_e_6852795737b0832aad0f03db115b52b7