### PR TITLE
Refactor repo indexing CLI

### DIFF
--- a/agentic_index_cli/__main__.py
+++ b/agentic_index_cli/__main__.py
@@ -10,7 +10,8 @@ import requests
 import structlog
 import typer
 
-from . import agentic_index, enricher, faststart, prune
+from . import cli as agentic_index
+from . import enricher, faststart, prune
 from .logging_config import configure_logging, configure_sentry
 
 app = typer.Typer(add_completion=True, help="Agentic Index CLI")

--- a/agentic_index_cli/cli.py
+++ b/agentic_index_cli/cli.py
@@ -1,0 +1,67 @@
+"""Command line interface for the ranking workflow."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+from rich.progress import track
+
+from .network import search_and_harvest
+from .render import changelog, load_previous, save_changelog, save_csv, save_markdown
+from .scoring import SCORE_KEY
+
+
+def sort_and_select(repos: List[Dict], limit: int = 100) -> List[Dict]:
+    """Return the top ``limit`` repos sorted by score."""
+    repos.sort(key=lambda x: x[SCORE_KEY], reverse=True)
+    return repos[:limit]
+
+
+def run_index(
+    min_stars: int = 0, iterations: int = 1, output: Path = Path("data")
+) -> None:
+    """Run the full indexing workflow."""
+    is_test = os.getenv("PYTEST_CURRENT_TEST") is not None
+    output.mkdir(parents=True, exist_ok=True)
+    prev_csv = output / "top100.csv"
+    prev_repos = load_previous(prev_csv)
+
+    final_repos = None
+    last_top = None
+    for _ in track(
+        range(iterations), description="ranking", disable=not sys.stderr.isatty()
+    ):
+        repos = search_and_harvest(min_stars)
+        top = sort_and_select(repos, 100)
+        names = [r["name"] for r in top]
+        if names == last_top:
+            break
+        last_top = names
+        final_repos = top
+    if final_repos is None:
+        final_repos = top
+
+    if not is_test or output != Path("data"):
+        save_csv(final_repos, output / "top100.csv")
+        save_markdown(final_repos, output / "top100.md")
+        changes = changelog(prev_repos, [r["name"] for r in final_repos])
+        save_changelog(changes, output / "CHANGELOG.md")
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description="Agentic Index Repo Indexer")
+    parser.add_argument("--min-stars", type=int, default=0)
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--output", type=Path, default=Path("data"))
+    args = parser.parse_args()
+
+    run_index(args.min_stars, args.iterations, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/agentic_index_cli/enricher.py
+++ b/agentic_index_cli/enricher.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from jsonschema import Draft7Validator
 
-from .agentic_index import (
+from .scoring import (
     categorize,
     compute_issue_health,
     compute_recency_factor,

--- a/agentic_index_cli/internal/rank.py
+++ b/agentic_index_cli/internal/rank.py
@@ -15,12 +15,12 @@ from pathlib import Path
 from jinja2 import Template
 
 import lib.quality_metrics  # ensure built-in metrics are registered
-from agentic_index_cli.agentic_index import (
+from agentic_index_cli.config import load_config
+from agentic_index_cli.scoring import (
     compute_issue_health,
     compute_recency_factor,
     license_freedom,
 )
-from agentic_index_cli.config import load_config
 from agentic_index_cli.validate import load_repos, save_repos
 from lib.metrics_registry import get_metrics
 

--- a/agentic_index_cli/internal/rank_main.py
+++ b/agentic_index_cli/internal/rank_main.py
@@ -8,12 +8,12 @@ from pathlib import Path
 from jinja2 import Template
 
 import lib.quality_metrics  # ensure built-in metrics are registered
-from agentic_index_cli.agentic_index import (
+from agentic_index_cli.config import load_config
+from agentic_index_cli.scoring import (
     compute_issue_health,
     compute_recency_factor,
     license_freedom,
 )
-from agentic_index_cli.config import load_config
 from agentic_index_cli.validate import load_repos, save_repos
 
 from .badges import generate_badges

--- a/agentic_index_cli/rank.py
+++ b/agentic_index_cli/rank.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-from .agentic_index import compute_score as _compute_score
+from .scoring import compute_score as _compute_score
 
 __all__ = ["compute_score"]
 

--- a/agentic_index_cli/render.py
+++ b/agentic_index_cli/render.py
@@ -1,0 +1,78 @@
+"""Output helpers for ranking results."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict, List
+
+from jinja2 import Template
+
+from .scoring import SCORE_KEY
+
+
+def save_csv(repos: List[Dict], path: Path) -> None:
+    """Write ``repos`` to ``path`` as CSV."""
+    keys = ["name", "stars", "last_commit", SCORE_KEY, "category", "description"]
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=keys)
+        writer.writeheader()
+        for r in repos:
+            writer.writerow({k: r[k] for k in keys})
+
+
+def save_markdown(repos: List[Dict], path: Path) -> None:
+    """Write a Markdown table of ``repos`` to ``path``."""
+    tmpl = Template(
+        """
+| # | Repo | ★ | Last Commit | Score | Category | One-liner |
+|---|------|----|------------|-------|----------|-----------|
+{% for i, r in rows %}| {{ i }} | {{ r.name }} | {{ r.stars }} | {{ r.date }} | {{ r.score }} | {{ r.category }} | {{ r.description }} |
+{% endfor %}"""
+    )
+    rows = [
+        (
+            i,
+            {
+                "name": r["name"],
+                "stars": r["stars"],
+                "date": r["last_commit"].split("T")[0],
+                "score": r[SCORE_KEY],
+                "category": r["category"],
+                "description": r["description"],
+            },
+        )
+        for i, r in enumerate(repos, 1)
+    ]
+    path.write_text(tmpl.render(rows=rows))
+
+
+def load_previous(path: Path) -> List[str]:
+    """Load previously ranked repository names from ``path``."""
+    if not path.exists():
+        return []
+    with path.open() as f:
+        reader = csv.DictReader(f)
+        return [row["name"] for row in reader]
+
+
+def changelog(old: List[str], new: List[str]) -> List[Dict]:
+    """Return changelog entries comparing old and new repo lists."""
+    old_set = set(old)
+    new_set = set(new)
+    changes = []
+    for name in new_set - old_set:
+        changes.append({"repo": name, "action": "Added"})
+    for name in old_set - new_set:
+        changes.append({"repo": name, "action": "Removed"})
+    return changes
+
+
+def save_changelog(changes: List[Dict], path: Path) -> None:
+    """Write changelog entries to ``path``."""
+    if not changes:
+        return
+    with path.open("w") as f:
+        f.write("| Repo | Action |\n|------|--------|\n")
+        for c in changes:
+            f.write(f"| {c['repo']} | {c['action']} |\n")

--- a/agentic_index_cli/scoring.py
+++ b/agentic_index_cli/scoring.py
@@ -1,0 +1,124 @@
+"""Scoring utilities for repositories."""
+
+from __future__ import annotations
+
+import math
+import time
+import uuid
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import structlog
+
+logger = structlog.get_logger(__name__).bind(file=__file__)
+
+SCORE_KEY = "AgenticIndexScore"
+
+PERMISSIVE_LICENSES = {
+    "mit",
+    "apache-2.0",
+    "bsd-2-clause",
+    "bsd-3-clause",
+    "isc",
+    "zlib",
+    "mpl-2.0",
+}
+VIRAL_LICENSES = {"gpl-3.0", "gpl-2.0", "agpl-3.0", "agpl-2.0"}
+
+
+def compute_recency_factor(pushed_at: str) -> float:
+    """Return a freshness score based on ``pushed_at`` timestamp."""
+    pushed_date = datetime.strptime(pushed_at, "%Y-%m-%dT%H:%M:%SZ")
+    days = (datetime.utcnow() - pushed_date).days
+    if days <= 30:
+        return 1.0
+    if days >= 365:
+        return 0.0
+    return max(0.0, 1 - (days - 30) / 335)
+
+
+def compute_issue_health(open_issues: int, closed_issues: int) -> float:
+    """Return ratio of closed to total issues."""
+    denom = open_issues + closed_issues + 1e-6
+    return 1 - open_issues / denom
+
+
+def readme_doc_completeness(readme: str) -> float:
+    """Return 1.0 if README is long and contains code blocks."""
+    words = len(readme.split())
+    has_code = "```" in readme
+    if words >= 300 and has_code:
+        return 1.0
+    return 0.0
+
+
+def license_freedom(license_spdx: Optional[str]) -> float:
+    """Score how permissive a license is."""
+    if not license_spdx:
+        return 0.0
+    key = license_spdx.lower()
+    if key in PERMISSIVE_LICENSES:
+        return 1.0
+    if key in VIRAL_LICENSES:
+        return 0.5
+    return 0.5
+
+
+def ecosystem_integration(topics: List[str], readme: str) -> float:
+    """Return 1.0 if popular ecosystem keywords are present."""
+    text = " ".join(topics).lower() + " " + readme.lower()
+    keywords = ["langchain", "plugin", "openai", "tool", "extension", "framework"]
+    for k in keywords:
+        if k in text:
+            return 1.0
+    return 0.0
+
+
+def categorize(description: str, topics: List[str]) -> str:
+    """Return a coarse category for a project."""
+    text = (description or "").lower() + " " + " ".join(topics).lower()
+    if "rag" in text or "retrieval" in text:
+        return "RAG-centric"
+    if "multi-agent" in text or "crew" in text or "team" in text:
+        return "Multi-Agent"
+    if "dev" in text or "tool" in text or "test" in text:
+        return "DevTools"
+    if any(domain in text for domain in ["video", "game", "finance", "security"]):
+        return "Domain-Specific"
+    if "experimental" in text or "research" in text:
+        return "Experimental"
+    return "General-purpose"
+
+
+def compute_score(repo: Dict, readme: str) -> float:
+    """Compute the Agentic Index score for ``repo``."""
+    request_id = str(uuid.uuid4())
+    log = logger.bind(func="compute_score", request_id=request_id)
+    start = time.perf_counter()
+    stars = repo.get("stargazers_count", 0)
+    open_issues = repo.get("open_issues_count", 0)
+    closed_issues = repo.get("closed_issues", 0)
+    recency = compute_recency_factor(repo.get("pushed_at"))
+    issue_health = compute_issue_health(open_issues, closed_issues)
+    doc_comp = readme_doc_completeness(readme)
+    lic = repo.get("license")
+    if isinstance(lic, dict):
+        lic = lic.get("spdx_id")
+    license_free = license_freedom(lic)
+    eco = ecosystem_integration(repo.get("topics", []), readme)
+    score = (
+        0.30 * math.log2(stars + 1)
+        + 0.25 * recency
+        + 0.20 * issue_health
+        + 0.15 * doc_comp
+        + 0.07 * license_free
+        + 0.03 * eco
+    )
+    final = round(score * 100 / 8, 2)
+    log.debug(
+        "score-computed",
+        repo=repo.get("full_name", repo.get("name")),
+        score=final,
+        duration=time.perf_counter() - start,
+    )
+    return final

--- a/agents.md
+++ b/agents.md
@@ -9,7 +9,7 @@ Agentic Index curates & ranks AI-agent repos so developers can quickly find reli
 | Agent Name | Trigger | Code Location | Main Function | Outputs |
 |------------|---------|---------------|---------------|---------|
 | ScraperCLI | manual / update.yml | `scripts/scrape_repos.py` | Fetch repos via GitHub API | `data/repos.json` |
-| MetricsScorer | update.yml | `agentic_index_cli/agentic_index.py` | Compute maintenance/docs/eco metrics | updated `repos.json` |
+| MetricsScorer | update.yml | `agentic_index_cli/scoring.py` | Compute maintenance/docs/eco metrics | updated `repos.json` |
 | RankerCLI | manual / update.yml | `agentic_index_cli/ranker.py` | Compute score & top-100 | `data/top100.md`, badges |
 | READMEInjector | pre-commit / update.yml | `agentic_index_cli/inject_readme.py` | Update README table | updated README |
 | FastStartPicker | manual | `agentic_index_cli/faststart.py` | Generate FAST_START | `FAST_START.md` |

--- a/api/sync.py
+++ b/api/sync.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 import structlog
 
-from agentic_index_cli.agentic_index import search_and_harvest
+from agentic_index_cli.network import search_and_harvest
 
 STATE_PATH = Path("state/sync_data.json")
 logger = structlog.get_logger(__name__).bind(file=__file__)

--- a/lib/quality_metrics.py
+++ b/lib/quality_metrics.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import math
 from typing import Iterable
 
-from agentic_index_cli.agentic_index import (
+from agentic_index_cli.scoring import (
     compute_issue_health,
     compute_recency_factor,
     license_freedom,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [project.scripts]
-agentic-index = "agentic_index_cli.__main__:main"
+agentic-index = "agentic_index_cli.cli:main"
 
 [project.optional-dependencies]
 docs = ["sphinx", "pydantic"]

--- a/tests/snapshots/README.md
+++ b/tests/snapshots/README.md
@@ -231,7 +231,7 @@ This isn't a static list. It's alive\! See [CHANGELOG.md](./CHANGELOG.md) for al
 Run the indexer to fetch fresh repo data:
 
 ```bash
-python -m agentic_index_cli.agentic_index --min-stars 50 --iterations 1 --output data
+python -m agentic_index_cli.cli --min-stars 50 --iterations 1 --output data
 ```
 
 The CLI reads tuning parameters from `agentic_index_cli/config.yaml`. Use

--- a/tests/test_agentic_index_network.py
+++ b/tests/test_agentic_index_network.py
@@ -1,7 +1,9 @@
 import base64
 import types
 
-import agentic_index_cli.agentic_index as ai
+import agentic_index_cli.network as ai
+import agentic_index_cli.render as rn
+import agentic_index_cli.scoring as sc
 
 
 class DummyResp:
@@ -78,11 +80,11 @@ def test_harvest_repo(monkeypatch):
     }
     monkeypatch.setattr(ai, "fetch_repo", lambda name: meta)
     monkeypatch.setattr(ai, "fetch_readme", lambda name: "README")
-    monkeypatch.setattr(ai, "compute_score", lambda r, rd: 1.0)
-    monkeypatch.setattr(ai, "categorize", lambda desc, t: "General")
+    monkeypatch.setattr(sc, "compute_score", lambda r, rd: 1.0)
+    monkeypatch.setattr(sc, "categorize", lambda desc, t: "General")
     res = ai.harvest_repo("owner/name")
     assert res["name"] == "owner/name"
-    assert ai.SCORE_KEY in res
+    assert sc.SCORE_KEY in res
 
 
 def test_error_branches(monkeypatch):
@@ -138,12 +140,12 @@ def test_search_topics_duplicate(monkeypatch):
 
 
 def test_changelog_and_save(tmp_path):
-    changes = ai.changelog(["a", "b"], ["b", "c"])
+    changes = rn.changelog(["a", "b"], ["b", "c"])
     path = tmp_path / "changelog.md"
-    ai.save_changelog(changes, path)
+    rn.save_changelog(changes, path)
     assert path.exists()
 
-    empty = ai.changelog(["a"], ["a"])
+    empty = rn.changelog(["a"], ["a"])
     path2 = tmp_path / "none.md"
-    ai.save_changelog(empty, path2)
+    rn.save_changelog(empty, path2)
     assert not path2.exists()

--- a/tests/test_agentic_index_utils.py
+++ b/tests/test_agentic_index_utils.py
@@ -1,4 +1,4 @@
-import agentic_index_cli.agentic_index as ai
+from agentic_index_cli import scoring as ai
 
 
 def test_compute_score_simple():

--- a/tests/test_categorize_more.py
+++ b/tests/test_categorize_more.py
@@ -1,4 +1,4 @@
-import agentic_index_cli.agentic_index as ai
+from agentic_index_cli import scoring as ai
 
 
 def test_categorize_branches():

--- a/tests/test_category_cli_integration.py
+++ b/tests/test_category_cli_integration.py
@@ -3,10 +3,10 @@ import runpy
 import sys
 from pathlib import Path
 
-import agentic_index_cli.agentic_index as ai
 import agentic_index_cli.enricher as enricher
 import agentic_index_cli.internal.inject_readme as inj
 import agentic_index_cli.internal.rank_main as rank
+from agentic_index_cli import scoring as ai
 
 
 def test_cli_all_categories(tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,8 +11,8 @@ def test_cli_help(tmp_path):
     )
     result = subprocess.run(["agentic-index", "--help"], capture_output=True, text=True)
     assert result.returncode == 0
-    assert "scrape" in result.stdout
-    assert "faststart" in result.stdout
+    assert "--min-stars" in result.stdout
+    assert "--iterations" in result.stdout
 
 
 def test_python_m_entrypoint():

--- a/tests/test_cli_exitcodes.py
+++ b/tests/test_cli_exitcodes.py
@@ -13,7 +13,7 @@ def test_network_exitcode():
         raise requests.RequestException("fail")
 
     with mock.patch(
-        "agentic_index_cli.agentic_index.http_utils.sync_get",
+        "agentic_index_cli.network.http_utils.sync_get",
         lambda *a, **k: (_ for _ in ()).throw(requests.RequestException("fail")),
     ):
         with pytest.raises(SystemExit) as exc:

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import agentic_index_cli.__main__ as main
-import agentic_index_cli.agentic_index as ai
+import agentic_index_cli.cli as ai
 
 
 def test_main_scrape(monkeypatch, tmp_path):

--- a/tests/test_quality_metrics_extra.py
+++ b/tests/test_quality_metrics_extra.py
@@ -1,7 +1,7 @@
 import math
 from datetime import datetime, timedelta
 
-import agentic_index_cli.agentic_index as ai
+from agentic_index_cli import scoring as ai
 from lib.quality_metrics import _clamp
 
 

--- a/tests/test_run_index.py
+++ b/tests/test_run_index.py
@@ -1,7 +1,7 @@
 import csv
 from pathlib import Path
 
-import agentic_index_cli.agentic_index as ai
+import agentic_index_cli.cli as ai
 
 
 def test_run_index_creates_outputs(tmp_path, monkeypatch):

--- a/tests/test_score_formula.py
+++ b/tests/test_score_formula.py
@@ -1,6 +1,6 @@
 import math
 
-import agentic_index_cli.agentic_index as ai
+from agentic_index_cli import scoring as ai
 
 
 def test_compute_score_formula():

--- a/tests/test_search_pagination.py
+++ b/tests/test_search_pagination.py
@@ -1,4 +1,4 @@
-import agentic_index_cli.agentic_index as ai
+import agentic_index_cli.network as ai
 
 
 def test_search_and_harvest_pagination(monkeypatch):


### PR DESCRIPTION
## Summary
- split agentic_index_cli/agentic_index.py into modules
- update imports and CLI entrypoint
- adjust tests for new module layout

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852817f8e0c832aa038c011f0e155e8