### PR TITLE
Centralize CLI templates

### DIFF
--- a/agentic_index_cli/internal/inject_readme.py
+++ b/agentic_index_cli/internal/inject_readme.py
@@ -13,7 +13,14 @@ import traceback
 import uuid
 
 import structlog
-from jinja2 import Template
+
+from agentic_index_cli.templates import (
+    FULL_ROW_TMPL,
+    SUMMARY_ROW_TMPL,
+)
+from agentic_index_cli.templates import clamp_name as _clamp_name
+from agentic_index_cli.templates import format_link as _format_link
+from agentic_index_cli.templates import short_desc as _short_desc
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 README_PATH = ROOT / "README.md"
@@ -41,46 +48,10 @@ DEFAULT_TOP_N = 100
 
 logger = structlog.get_logger(__name__).bind(file=__file__)
 
-SUMMARY_ROW_TMPL = Template(
-    "| {{ i }} | {{ name }} | {{ desc }} | {{ score }} | "
-    "{{ stars }} | {{ sdelta }} |"
-)
-FULL_ROW_TMPL = Template(
-    "| {{ i }} | {{ name }} | {{ score }} | {{ stars }} | {{ sdelta }} | "
-    "{{ scdelta }} | {{ rec }} | {{ health }} | {{ docs }} | {{ licfr }} | "
-    "{{ eco }} | {{ log2 }} | {{ cat }} |"
-)
-
 
 def _markers(n: int) -> tuple[str, str]:
     """Return start and end markers for ``n``."""
     return f"<!-- TOP{n}:START -->", f"<!-- TOP{n}:END -->"
-
-
-def _clamp_name(name: str, limit: int = 28) -> str:
-    """Return ``name`` truncated and escaped for markdown."""
-    safe = name.replace("|", "\\|").replace("`", "\\`")
-    if len(safe) <= limit:
-        return safe
-    return safe[: limit - 3] + "..."
-
-
-def _format_link(name: str, url: str | None, *, limit: int = 28) -> str:
-    """Return a markdown link for ``name`` clamped to ``limit``."""
-    text = _clamp_name(name, limit)
-    if url:
-        return f"[{text}]({url})"
-    return text
-
-
-def _short_desc(desc: str | None, limit: int = 150) -> str:
-    """Return ``desc`` escaped for markdown and truncated."""
-    if not desc:
-        return ""
-    desc = desc.replace("|", "/").replace("`", "\\`").replace("\n", " ")
-    if len(desc) <= limit:
-        return desc
-    return desc[: limit - 3] + "..."
 
 
 def _load_rows(

--- a/agentic_index_cli/internal/rank.py
+++ b/agentic_index_cli/internal/rank.py
@@ -12,8 +12,6 @@ import shutil
 import urllib.request
 from pathlib import Path
 
-from jinja2 import Template
-
 import lib.quality_metrics  # ensure built-in metrics are registered
 from agentic_index_cli.config import load_config
 from agentic_index_cli.scoring import (
@@ -21,18 +19,13 @@ from agentic_index_cli.scoring import (
     compute_recency_factor,
     license_freedom,
 )
+from agentic_index_cli.templates import SUMMARY_ROW_TMPL, format_link, short_desc
 from agentic_index_cli.validate import load_repos, save_repos
 from lib.metrics_registry import get_metrics
-
-from .inject_readme import _format_link, _short_desc
 
 # ─────────────────────────  Scoring & categorisation  ──────────────────────────
 
 SCORE_KEY = "AgenticIndexScore"
-
-SUMMARY_ROW_TMPL = Template(
-    "| {{ i }} | {{ name }} | {{ desc }} | {{ score }} | " "{{ stars }} | {{ delta }} |"
-)
 
 
 def compute_score(repo: dict) -> float:
@@ -232,8 +225,8 @@ def main(json_path: str = "data/repos.json", *, config: dict | None = None) -> N
     rows = [
         SUMMARY_ROW_TMPL.render(
             i=i,
-            name=_format_link(repo["name"], repo.get("html_url")),
-            desc=_short_desc(repo.get("description")),
+            name=format_link(repo["name"], repo.get("html_url")),
+            desc=short_desc(repo.get("description")),
             score=f"{repo[SCORE_KEY]:.2f}",
             stars=repo.get("stars", repo.get("stargazers_count", 0)),
             delta=fmt(repo["stars_delta"]),

--- a/agentic_index_cli/internal/rank_main.py
+++ b/agentic_index_cli/internal/rank_main.py
@@ -5,8 +5,6 @@ import json
 import os
 from pathlib import Path
 
-from jinja2 import Template
-
 import lib.quality_metrics  # ensure built-in metrics are registered
 from agentic_index_cli.config import load_config
 from agentic_index_cli.scoring import (
@@ -14,19 +12,15 @@ from agentic_index_cli.scoring import (
     compute_recency_factor,
     license_freedom,
 )
+from agentic_index_cli.templates import SUMMARY_ROW_TMPL, format_link, short_desc
 from agentic_index_cli.validate import load_repos, save_repos
 
 from .badges import generate_badges
-from .inject_readme import _format_link, _short_desc
 from .scoring import SCORE_KEY, compute_score
 from .scoring import infer_category as _infer_category
 from .snapshot import persist_history, write_by_category
 
 infer_category = _infer_category
-
-SUMMARY_ROW_TMPL = Template(
-    "| {{ i }} | {{ name }} | {{ desc }} | {{ score }} | {{ stars }} | {{ delta }} |"
-)
 
 
 def main(json_path: str = "data/repos.json", *, config: dict | None = None) -> None:
@@ -126,8 +120,8 @@ def main(json_path: str = "data/repos.json", *, config: dict | None = None) -> N
     rows = [
         SUMMARY_ROW_TMPL.render(
             i=i,
-            name=_format_link(repo["name"], repo.get("html_url")),
-            desc=_short_desc(repo.get("description")),
+            name=format_link(repo["name"], repo.get("html_url")),
+            desc=short_desc(repo.get("description")),
             score=f"{repo[SCORE_KEY]:.2f}",
             stars=repo.get("stars", repo.get("stargazers_count", 0)),
             delta=fmt(repo["stars_delta"]),

--- a/agentic_index_cli/templates.py
+++ b/agentic_index_cli/templates.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from jinja2 import Template
+
+SUMMARY_ROW_TMPL = Template(
+    "| {{ i }} | {{ name }} | {{ desc }} | {{ score }} | {{ stars }} | {{ delta }} |"
+)
+
+FULL_ROW_TMPL = Template(
+    "| {{ i }} | {{ name }} | {{ score }} | {{ stars }} | {{ sdelta }} | {{ scdelta }} | {{ rec }} | {{ health }} | {{ docs }} | {{ licfr }} | {{ eco }} | {{ log2 }} | {{ cat }} |"
+)
+
+__all__ = [
+    "SUMMARY_ROW_TMPL",
+    "FULL_ROW_TMPL",
+    "clamp_name",
+    "format_link",
+    "short_desc",
+]
+
+
+def clamp_name(name: str, limit: int = 28) -> str:
+    """Return ``name`` truncated and escaped for markdown."""
+    safe = name.replace("|", "\\|").replace("`", "\\`")
+    if len(safe) <= limit:
+        return safe
+    return safe[: limit - 3] + "..."
+
+
+def format_link(name: str, url: str | None, *, limit: int = 28) -> str:
+    """Return a markdown link for ``name`` clamped to ``limit``."""
+    text = clamp_name(name, limit)
+    if url:
+        return f"[{text}]({url})"
+    return text
+
+
+def short_desc(desc: str | None, limit: int = 150) -> str:
+    """Return ``desc`` escaped for markdown and truncated."""
+    if not desc:
+        return ""
+    desc = desc.replace("|", "/").replace("`", "\\`").replace("\n", " ")
+    if len(desc) <= limit:
+        return desc
+    return desc[: limit - 3] + "..."


### PR DESCRIPTION
## Summary
- add `templates.py` with Jinja2 templates and helpers
- refactor inject_readme and ranking modules to use templates

Closes #GH-DEMO-1

## Testing
- `black --check .`
- `isort --check-only .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog', 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_68528891585c832ab2088504744c2942