### PR TITLE
Update CI setup docs

### DIFF
--- a/docs/CI_SETUP.md
+++ b/docs/CI_SETUP.md
@@ -10,6 +10,19 @@ pip install -i https://pypi.org/simple \
 
 Using this mirror (Option B) avoids firewall issues while keeping the installation steps simple.
 
+## Setting `PIP_INDEX_URL`
+
+Some environments block direct internet access. Set the `PIP_INDEX_URL` environment
+variable to your internal PyPI mirror so all `pip` commands automatically use it.
+
+```bash
+export PIP_INDEX_URL=https://pypi.mycompany.com/simple
+pip install -r requirements.txt
+```
+
+`pip install -r requirements.txt` must succeed before running `pip-audit` so the
+audit tool can resolve every dependency.
+
 ## Example Workflow Step
 
 Install the package in editable mode and run the ranking command:


### PR DESCRIPTION
## Summary
- document how to configure `PIP_INDEX_URL` for offline environments
- clarify that installing requirements must succeed before `pip-audit`

## Testing
- `black --check . && isort --check-only .`
- `CI_OFFLINE=1 PYTHONPATH="$PWD" pytest -q` *(fails: 2 failed, 202 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68528b8af474832a8d99796be1c5f8fe