### PR TITLE
Clarify setup-env for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,11 +284,17 @@ npx puppeteer browsers install chrome
 sudo apt-get install -y chromium
 ```
 
+### Running Tests
+
 Run tests with:
 
 ```bash
 pytest -q
 ```
+
+`pytest` will fail if optional development packages are missing.
+Run `source scripts/setup-env.sh` or install `dev-requirements.txt`
+to ensure all dependencies are available.
 
 CI runs tests with network access disabled. Set `CI_OFFLINE=1` or run
 `pytest --disable-socket` locally to replicate the offline environment.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -38,6 +38,10 @@ pyenv local 3.11.12
 pip install -r requirements.lock
 ```
 
+For a full environment setup—including every package needed for the test
+suite—source `scripts/setup-env.sh`. The script installs the contents of
+`dev-requirements.txt` and ensures `pytest` can run without missing modules.
+
 ## Pre-commit Hooks
 Activate hooks so formatting and lint checks run before each commit. The hooks
 run **Black**, **Isort**, **Flake8**, and the unit tests:


### PR DESCRIPTION
## Summary
- note that setup-env.sh installs test dependencies in ONBOARDING guide
- warn about missing packages in README test section

## Testing
- `black --check .`
- `isort --check-only .`
- `CI_OFFLINE=1 PYTHONPATH="$PWD" pytest -q` *(fails: 49 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68528f68ff7c832a809df705d904b5dc