### PR TITLE
Add pip-licenses docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,19 @@ trivy fs .
 ```
 
 
+### License Summary
+
+Generate a report of third-party licenses to help verify compliance.
+Install dependencies as described in
+[docs/CI_SETUP.md](./docs/CI_SETUP.md) and run:
+
+```bash
+pip-licenses --format=json --output-file=reports/licenses.json
+```
+
+The resulting JSON file lists each package and license used by the project.
+
+
 
 
 


### PR DESCRIPTION
## Summary
- document how to generate a dependency license report

## Testing
- `PYTHONPATH="$PWD" pytest -q` *(fails: Missing required environment variables)*
- `black --check .`
- `isort --check-only .`


------
https://chatgpt.com/codex/tasks/task_e_685290a528b8832abb4e41845ed96db9