### PR TITLE
Add benchmark for star-delta ops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,30 @@ jobs:
           name: bandit
           path: bandit.json
 
+  benchmarks:
+    needs: tests
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    env:
+      PYTHONFAULTHANDLER: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: Install deps
+        run: |
+          pip install -r requirements.txt
+          pip install -e '.[dev]'
+      - name: Run benchmarks
+        run: python scripts/benchmark_ops.py
+
   badge-update:
     runs-on: ubuntu-latest
     permissions:
@@ -243,7 +267,7 @@ jobs:
           delete-branch: true
 
   audit-summary:
-    needs: [lint-format, type-check, tests, pipeline-integrity, security-scan, badge-update]
+    needs: [lint-format, type-check, tests, pipeline-integrity, security-scan, benchmarks, badge-update]
     runs-on: ubuntu-latest
     if: always()
     env:
@@ -259,4 +283,5 @@ jobs:
           echo "| Tests | ${{ needs.tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Pipeline Integrity | ${{ needs.pipeline-integrity.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Security Scan | ${{ needs.security-scan.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Benchmarks | ${{ needs.benchmarks.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Badge Update | ${{ needs.badge-update.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -16,5 +16,11 @@ Large `repos.json` files can slow down table generation and diff checks.
   pip install ijson
   ```
   Then call `load_repos(..., use_stream=True)`.
-- Run `scripts/benchmark_ops.py` to measure sort and diff times. The script
-  prints a warning when operations exceed built-in baselines.
+- Run `scripts/benchmark_ops.py` to measure sorting, diff, and star-delta
+  calculations. The script prints a warning when operations exceed built-in
+  baselines.
+
+## CI Benchmarks
+
+An optional `benchmarks` job in the CI workflow runs the benchmark script on
+pull requests. Results appear in the job log but do not gate the build.

--- a/scripts/benchmark_ops.py
+++ b/scripts/benchmark_ops.py
@@ -9,13 +9,14 @@ from pathlib import Path
 REPOS_PATH = Path("data/repos.json")
 BASELINE_SORT = 0.5
 BASELINE_DIFF = 0.2
+BASELINE_DELTA = 0.1
 THRESHOLD = 1.5
 
 
 def bench_sort() -> float:
     from agentic_index_cli.validate import load_repos
 
-    repos = load_repos(REPOS_PATH, cache=True, stream=False)
+    repos = load_repos(REPOS_PATH, use_cache=True, use_stream=False)
     start = time.perf_counter()
     repos.sort(key=lambda r: r.get("AgenticIndexScore", 0), reverse=True)
     dur = time.perf_counter() - start
@@ -32,7 +33,7 @@ def bench_sort() -> float:
 def bench_diff() -> float:
     from agentic_index_cli.internal.inject_readme import build_readme, diff
 
-    new_text = build_readme(end_newline=True)
+    new_text = build_readme(top_n=50)
     start = time.perf_counter()
     _ = diff(new_text)
     dur = time.perf_counter() - start
@@ -46,6 +47,42 @@ def bench_diff() -> float:
     return dur
 
 
+def bench_stars_delta() -> float:
+    """Benchmark star delta calculations."""
+    from agentic_index_cli.validate import load_repos
+
+    repos = load_repos(REPOS_PATH, use_cache=True, use_stream=False)
+    snapshot_path = Path("data/last_snapshot.txt")
+    prev_map: dict[str, dict] = {}
+    if snapshot_path.exists():
+        prev_path = Path(snapshot_path.read_text().strip())
+        if not prev_path.is_absolute():
+            prev_path = Path("data/history") / prev_path.name
+        if prev_path.exists():
+            prev_repos = load_repos(prev_path, use_cache=True, use_stream=False)
+            prev_map = {r.get("full_name", r.get("name")): r for r in prev_repos}
+
+    start = time.perf_counter()
+    for repo in repos:
+        prev = prev_map.get(repo.get("full_name", repo.get("name")))
+        if prev:
+            repo["stars_delta"] = repo.get("stars", 0) - prev.get(
+                "stars", prev.get("stargazers_count", 0)
+            )
+        else:
+            repo["stars_delta"] = "+new"
+    dur = time.perf_counter() - start
+    if dur > BASELINE_DELTA * THRESHOLD:
+        print(
+            f"WARNING: star delta calc took {dur:.3f}s, baseline {BASELINE_DELTA:.3f}s",
+            file=sys.stderr,
+        )
+    else:
+        print(f"stars_delta {dur:.3f}s")
+    return dur
+
+
 if __name__ == "__main__":
     bench_sort()
     bench_diff()
+    bench_stars_delta()

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Wrapper script for devcontainer initialization
-bash "$(dirname "$0")/agent-setup.sh"
+bash "$(dirname "${BASH_SOURCE[0]}")/agent-setup.sh"
 
 # Ensure the script is sourced so exports persist
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then


### PR DESCRIPTION
## Summary
- warn if star-delta or sort/diff benchmarks regress
- document benchmarks in PERFORMANCE guide
- run benchmark script in optional CI job
- fix setup-env path resolution

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685297e34f18832abd4b5c2fbd1ce72a