### PR TITLE
Add benchmark job and star-delta timing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      run-benchmarks:
+        description: "Run benchmarking job"
+        default: 'false'
+        required: false
 
 defaults:
   run:
@@ -199,6 +205,36 @@ jobs:
         with:
           name: bandit
           path: bandit.json
+
+  benchmarks:
+    needs: tests
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run-benchmarks == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      PYTHONFAULTHANDLER: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: Install deps
+        run: |
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
+          pip install -e '.[dev]'
+      - name: Run benchmarks
+        run: python scripts/benchmark_ops.py | tee benchmark.log
+      - name: Upload benchmark log
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmarks
+          path: benchmark.log
 
   badge-update:
     runs-on: ubuntu-latest

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -15,6 +15,13 @@ Large `repos.json` files can slow down table generation and diff checks.
   ```bash
   pip install ijson
   ```
-  Then call `load_repos(..., use_stream=True)`.
-- Run `scripts/benchmark_ops.py` to measure sort and diff times. The script
-  prints a warning when operations exceed built-in baselines.
+- Then call `load_repos(..., use_stream=True)`.
+- Run `scripts/benchmark_ops.py` to benchmark sort, diff and star-delta
+  calculations. The script prints a warning when any operation exceeds its
+  baseline.
+
+### CI Benchmarks
+
+The `benchmarks` job in `ci.yml` runs only when triggered via
+`workflow_dispatch` with `run-benchmarks: true`. It executes the benchmarking
+script and uploads the results as an artifact.


### PR DESCRIPTION
## Summary
- measure star-delta calculations in `benchmark_ops.py`
- describe optional benchmark run in PERFORMANCE docs
- add optional `benchmarks` job to CI workflow

## Testing
- `black --check . && isort --check-only .`
- `CI_OFFLINE=1 PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68529433dce4832a8a89d0f000f7fdc0