### PR TITLE
Add tests for http_utils and json_utils

### DIFF
--- a/tests/fixtures/README_fixture.md
+++ b/tests/fixtures/README_fixture.md
@@ -284,11 +284,17 @@ npx puppeteer browsers install chrome
 sudo apt-get install -y chromium
 ```
 
+### Running Tests
+
 Run tests with:
 
 ```bash
 pytest -q
 ```
+
+`pytest` will fail if optional development packages are missing.
+Run `source scripts/setup-env.sh` or install `dev-requirements.txt`
+to ensure all dependencies are available.
 
 CI runs tests with network access disabled. Set `CI_OFFLINE=1` or run
 `pytest --disable-socket` locally to replicate the offline environment.

--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -1,0 +1,110 @@
+import asyncio
+from types import SimpleNamespace
+from unittest import mock
+
+import aiohttp
+import pytest
+
+from agentic_index_cli.internal import http_utils
+
+
+class DummyResponse:
+    def __init__(self, status=200, headers=None, text="ok"):
+        self.status = status
+        self.headers = headers or {}
+        self._text = text
+
+    async def text(self):
+        return self._text
+
+
+class DummySession:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+
+    def get(self, *a, **k):
+        resp = next(self.responses)
+
+        class CM:
+            async def __aenter__(self_inner):
+                if isinstance(resp, Exception):
+                    raise resp
+                return resp
+
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                pass
+
+        return CM()
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def test_async_get_success(monkeypatch):
+    resp = DummyResponse(status=200, headers={"X": "Y"}, text="data")
+    session = DummySession([resp])
+    result = run_async(http_utils.async_get("http://x", session=session, retries=1))
+    assert result.status_code == 200
+    assert result.headers["X"] == "Y"
+    assert result.text == "data"
+
+
+def test_rate_limit_retry(monkeypatch):
+    resp1 = DummyResponse(
+        status=403,
+        headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "10"},
+    )
+    resp2 = DummyResponse(status=200)
+    session = DummySession([resp1, resp2])
+    sleep_calls = []
+
+    async def fake_sleep(t):
+        sleep_calls.append(t)
+
+    monkeypatch.setattr(http_utils.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(http_utils.time, "time", lambda: 5)
+    result = run_async(http_utils.async_get("http://x", session=session, retries=2))
+    assert result.status_code == 200
+    assert sleep_calls == [5]
+
+
+def test_server_error_retry(monkeypatch):
+    resp1 = DummyResponse(status=500)
+    resp2 = DummyResponse(status=200)
+    session = DummySession([resp1, resp2])
+    sleep_calls = []
+
+    async def fake_sleep(t):
+        sleep_calls.append(t)
+
+    monkeypatch.setattr(http_utils.asyncio, "sleep", fake_sleep)
+    result = run_async(http_utils.async_get("http://x", session=session, retries=2))
+    assert result.status_code == 200
+    assert sleep_calls == [1]
+
+
+def test_client_error(monkeypatch):
+    session = DummySession([aiohttp.ClientError("boom")])
+    with pytest.raises(aiohttp.ClientError):
+        run_async(http_utils.async_get("http://x", session=session, retries=1))
+
+
+def test_sync_get(monkeypatch):
+    async def fake_async_get(url, *, session, **kw):
+        return http_utils.Response(201, {"A": "B"}, '{"v": 1}')
+
+    monkeypatch.setattr(http_utils, "async_get", fake_async_get)
+
+    class CS:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(aiohttp, "ClientSession", CS)
+    resp = http_utils.sync_get("http://x")
+    assert resp.status_code == 201
+    assert resp.headers["A"] == "B"
+    assert resp.json() == {"v": 1}

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,53 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from agentic_index_cli.internal import json_utils
+
+
+def test_load_basic(tmp_path):
+    p = tmp_path / "data.json"
+    p.write_text(json.dumps({"a": 1}))
+    data = json_utils.load_json(p)
+    assert data == {"a": 1}
+
+
+def test_load_cache(tmp_path):
+    p = tmp_path / "cache.json"
+    json_utils._cache.clear()
+    p.write_text(json.dumps({"x": 2}))
+    first = json_utils.load_json(p, cache=True)
+    p.write_text(json.dumps({"x": 3}))  # change file but keep mtime
+    mock_stat = mock.Mock(st_mtime=p.stat().st_mtime)
+    with mock.patch.object(Path, "stat", return_value=mock_stat):
+        second = json_utils.load_json(p, cache=True)
+    assert first == {"x": 2}
+    assert second == first
+
+
+def test_load_stream(monkeypatch, tmp_path):
+    p = tmp_path / "stream.json"
+    p.write_text(json.dumps([1, 2, 3]))
+    fake_ijson = SimpleNamespace(load=lambda fh: [1, 2, 3])
+    monkeypatch.setitem(sys.modules, "ijson", fake_ijson)
+    data = json_utils.load_json(p, stream=True)
+    assert data == [1, 2, 3]
+
+
+def test_stream_fallback(monkeypatch, tmp_path):
+    p = tmp_path / "data.json"
+    p.write_text(json.dumps([4]))
+    monkeypatch.setitem(sys.modules, "ijson", None)
+    data = json_utils.load_json(p, stream=True)
+    assert data == [4]
+
+
+def test_invalid_json(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text("{")
+    with pytest.raises(Exception):
+        json_utils.load_json(p)


### PR DESCRIPTION
## Summary
- add unit tests for new internal modules `http_utils` and `json_utils`
- update README fixture

## Testing
- `PYTHONPATH="$PWD" pytest -q`
- `black --check .`
- `isort --check-only .`

------
https://chatgpt.com/codex/tasks/task_e_685291b53c14832a96dcd566289918c9