### PR TITLE
Add config validation

### DIFF
--- a/agentic_index_cli/config.py
+++ b/agentic_index_cli/config.py
@@ -5,13 +5,47 @@ from __future__ import annotations
 from pathlib import Path
 
 import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 DEFAULT_PATH = Path(__file__).with_name("config.yaml")
 
 
+class RankingConfig(BaseModel):
+    """Configuration options for ranking."""
+
+    top_n: int = 100
+    delta_days: int = 7
+    min_stars: int = 0
+
+
+class OutputConfig(BaseModel):
+    """Options controlling CLI output."""
+
+    markdown_table_limit: int = 100
+
+
+class AppConfig(BaseModel):
+    """Root configuration model for the CLI."""
+
+    ranking: RankingConfig = Field(default_factory=RankingConfig)
+    output: OutputConfig = Field(default_factory=OutputConfig)
+
+    model_config = ConfigDict(extra="forbid")
+
+
 def load_config(path: str | Path | None = None) -> dict:
-    """Return YAML config as a dictionary."""
+    """Return validated configuration from ``path``."""
     p = Path(path) if path else DEFAULT_PATH
     with p.open("r", encoding="utf-8") as f:
-        data = yaml.safe_load(f) or {}
-    return data
+        raw = yaml.safe_load(f) or {}
+
+    try:
+        cfg = AppConfig(**raw)
+    except ValidationError as exc:  # pragma: no cover - validated in tests
+        errors = "; ".join(
+            f"{'.'.join(str(x) for x in err['loc'])}: {err['msg']}"
+            for err in exc.errors()
+        )
+        raise ValueError(f"invalid config file {p}: {errors}") from None
+
+    return cfg.model_dump(exclude_none=True)

--- a/agentic_index_cli/ranker.py
+++ b/agentic_index_cli/ranker.py
@@ -16,11 +16,14 @@ main = rank_main
 @click.argument("path", default="data/repos.json")
 @config_option
 def _cli(path: str, config: str | None) -> None:
-    cfg = load_config(config) if config else None
-    if cfg is None:
-        main(path)
-    else:
-        main(path, config=cfg)
+    """Wrapper for the ranking CLI."""
+    try:
+        cfg = load_config(config)
+    except ValueError as exc:
+        click.echo(f"Config error: {exc}", err=True)
+        raise SystemExit(1)
+
+    main(path, config=cfg)
 
 
 def cli(argv: list[str] | None = None) -> None:

--- a/tasks.yml
+++ b/tasks.yml
@@ -45,7 +45,7 @@
   component: code
   dependencies: []
   priority: 3
-  status: todo
+  status: done
 - id: CR-AGENTIC-006
   description: Build integration tests for the API server (`api_server.py`), starting a test instance and exercising all REST endpoints including failure cases
   component: tests

--- a/tests/test_cli_wrappers.py
+++ b/tests/test_cli_wrappers.py
@@ -24,12 +24,14 @@ def test_scraper_cli(monkeypatch):
 def test_ranker_cli(monkeypatch, tmp_path):
     called = {}
 
-    def fake_main(path):
+    def fake_main(path, *, config=None):
         called["path"] = path
+        called["config"] = config
 
     monkeypatch.setattr(ranker, "main", fake_main)
     ranker.cli([str(tmp_path / "repos.json")])
     assert called["path"].endswith("repos.json")
+    assert isinstance(called["config"], dict)
 
 
 def test_inject_cli(monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from agentic_index_cli.config import load_config
 
 
@@ -57,3 +59,16 @@ output:
     top_md = tmp_path / "data" / "top100.md"
     lines = [l for l in top_md.read_text().splitlines() if l.startswith("|")]
     assert len(lines) == 3
+
+
+def test_invalid_config(tmp_path):
+    bad_cfg = tmp_path / "bad.yaml"
+    bad_cfg.write_text(
+        """
+ranking:
+  top_n: wrong
+"""
+    )
+
+    with pytest.raises(ValueError):
+        load_config(bad_cfg)


### PR DESCRIPTION
## Summary
- validate `config.yaml` using Pydantic
- surface configuration errors in the `ranker` CLI
- test validation errors and update CLI tests
- mark CR-AGENTIC-005 as done

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a2a8f97c832aa4d3fd3fcc4b0f5f