### PR TITLE
Enhance HTTP retry/backoff logic

### DIFF
--- a/tests/test_agentic_index_network.py
+++ b/tests/test_agentic_index_network.py
@@ -19,7 +19,7 @@ class DummyResp:
 def test_github_search(monkeypatch):
     captured = {}
 
-    def fake_get(url, params=None, headers=None):
+    def fake_get(url, params=None, headers=None, **_):
         captured["params"] = params
         return DummyResp({"items": ["ok"]})
 

--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -86,7 +86,7 @@ def test_server_error_retry(monkeypatch):
 
 def test_client_error(monkeypatch):
     session = DummySession([aiohttp.ClientError("boom")])
-    with pytest.raises(aiohttp.ClientError):
+    with pytest.raises(http_utils.APIError):
         run_async(http_utils.async_get("http://x", session=session, retries=1))
 
 


### PR DESCRIPTION
Closes #38

## Summary
- add `DEFAULT_RETRIES`, `DEFAULT_TIMEOUT`, and `DEFAULT_BACKOFF` settings in `http_utils`
- expose corresponding environment driven constants in `network.py`
- allow configuring retries, timeout and backoff when making HTTP requests
- wrap request failures in `APIError`
- update tests for new parameters

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a2a47edc832aba300e4788260ff3