### PR TITLE
Add api_server failure tests

### DIFF
--- a/tests/test_api_issue.py
+++ b/tests/test_api_issue.py
@@ -39,3 +39,56 @@ def test_issue_missing_field(monkeypatch):
         json={"repo": "o/r", "type": "comment", "body": "x"},
     )
     assert resp.status_code == 400
+
+
+def test_issue_create(monkeypatch):
+    called = {}
+
+    def fake_create(title, body, repo, *, token=None):
+        called["args"] = (title, body, repo, token)
+        return "u"
+
+    monkeypatch.setattr(api, "create_issue", fake_create)
+    client = TestClient(api.app)
+    resp = client.post(
+        "/issue",
+        json={"repo": "o/r", "type": "issue", "title": "t", "body": "msg"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"url": "u"}
+    assert called["args"] == ("t", "msg", "o/r", None)
+
+
+def test_issue_create_missing_title(monkeypatch):
+    client = TestClient(api.app)
+    resp = client.post(
+        "/issue",
+        json={"repo": "o/r", "type": "issue", "body": "msg"},
+    )
+    assert resp.status_code == 400
+
+
+def test_issue_error(monkeypatch):
+    def bad_create(*a, **k):
+        raise api.APIError("boom")
+
+    monkeypatch.setattr(api, "create_issue", bad_create)
+    client = TestClient(api.app)
+    resp = client.post(
+        "/issue",
+        json={"repo": "o/r", "type": "issue", "title": "t", "body": "msg"},
+    )
+    assert resp.status_code == 502
+
+
+def test_comment_error(monkeypatch):
+    def bad_comment(*a, **k):
+        raise api.APIError("nope")
+
+    monkeypatch.setattr(api, "post_comment", bad_comment)
+    client = TestClient(api.app)
+    resp = client.post(
+        "/issue",
+        json={"repo": "o/r", "type": "comment", "issue_number": 1, "body": "msg"},
+    )
+    assert resp.status_code == 502


### PR DESCRIPTION
## Summary
- test api_server's /issue endpoint for new issue and error cases

## Testing
- `PYTHONPATH="$PWD" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852a5232814832abc0b5d031a966e3f