### PR TITLE
Update CI for coverage and sbom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Run tests with coverage
         env:
           PYTHONHASHSEED: 0
-        run: pytest --cov=agentic_index_cli --cov-report=xml --full-trace
+        run: pytest --cov=agentic_index_cli --cov-report=xml --cov-fail-under=80 --full-trace
       - name: Enforce coverage threshold
         run: python scripts/coverage_gate.py coverage.xml
       - name: Upload coverage

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,6 +17,13 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v3
+      - name: Generate SBOM
+        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: sbom.cdx.json
       # To update, run:
       # git ls-remote --tags https://github.com/aquasecurity/trivy-action.git | \
       #   sort -t '/' -k3 -V | tail -n1
@@ -29,6 +36,11 @@ jobs:
           exit-code: 1
           format: sarif
           output: trivy-results.sarif
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.cdx.json
       - name: Upload Trivy scan results
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
## Summary
- enforce coverage gate in pytest
- upload SBOM before Trivy scan

Closes #0

------
https://chatgpt.com/codex/tasks/task_e_6852aad2217c832ab7133bc74d1af598