### PR TITLE
Fix docs links and add mkdocs guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,15 @@ To run the scraping and ranking tools locally, install the CLI:
 pip install agentic-index-cli
 ```
 
+### Building the Documentation
+
+Install MkDocs and serve the site locally to preview changes:
+
+```bash
+pip install mkdocs-material mkdocstrings[python]
+mkdocs serve
+```
+
 ### Schema Migrations
 
 Older `repos.json` files may use a previous schema version. Upgrade them in

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -5,7 +5,7 @@ Welcome! This document collects everything you need to set up a working developm
 
 ## Table of Contents
 - [Prerequisites](#prerequisites)
-- [Fork & Clone](#fork--clone)
+- [Fork & Clone](#fork-clone)
 - [Install Dependencies](#install-dependencies)
 - [Pre-commit Hooks](#pre-commit-hooks)
 - [Running Tests](#running-tests)

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -1,6 +1,6 @@
 # Developer Contributing Notes
 
-This section supplements the main [CONTRIBUTING.md](../../CONTRIBUTING.md).
+This section supplements the main [CONTRIBUTING.md](https://github.com/adrianwedd/Agentic-Index/blob/main/CONTRIBUTING.md).
 
 ## Regenerating Fixtures
 

--- a/docs/readme_review/accessibility.md
+++ b/docs/readme_review/accessibility.md
@@ -1,22 +1,22 @@
 ## Findings
 
 *   **Alt Text for Images and Badges:**
-    *   Most images (badges) have alt text (e.g., `![build](badges/build.svg)`).
+    *   Most images (badges) have alt text (e.g., `![build](../../badges/build.svg)`).
     *   However, the alt text is often simplistic (e.g., "build", "coverage", "security") and could be more descriptive of the badge's meaning or the status it conveys (e.g., "Build status: passing", "Code coverage: 80%").
-    *   Line 24: `![build](badges/build.svg)` - Alt text "build".
+    *   Line 24: `![build](../../badges/build.svg)` - Alt text "build".
     *   Line 25: `![coverage](https://img.shields.io/badge/coverage-80%25-brightgreen)` - Alt text "coverage".
     *   Line 26: `![security](https://img.shields.io/badge/security-0%20issues-brightgreen)` - Alt text "security".
-    *   Line 27: `![docs](badges/docs.svg)` - Alt text "docs".
+    *   Line 27: `![docs](../../badges/docs.svg)` - Alt text "docs".
     *   Line 28: `![Site](https://img.shields.io/website?down_message=offline&up_message=online&url=https%3A%2F%2Fadrianwedd.github.io%2FAgentic-Index)` - Alt text "Site".
-    *   Line 29: `![license](badges/license.svg)` - Alt text "license".
-    *   Line 30: `![PyPI](badges/pypi.svg)` - Alt text "PyPI".
+    *   Line 29: `![license](../../badges/license.svg)` - Alt text "license".
+    *   Line 30: `![PyPI](../../badges/pypi.svg)` - Alt text "PyPI".
     *   Line 31: `![Release Notes](https://img.shields.io/github/release/adrianwedd/Agentic-Index?include_prereleases)` - Alt text "Release Notes".
-    *   The alt text for `![System Architecture](docs/architecture.svg)` (Line 207) is good ("System Architecture").
+    *   The alt text for `![System Architecture](../architecture.svg)` (Line 207) is good ("System Architecture").
     *   Alt text for footer badges (Line 298) like "Last Sync", "Top Repo", "Repo Count" are adequate.
 
 *   **Meaningful Link Text:**
-    *   Most link texts are descriptive and clearly indicate the destination (e.g., `[🚀 Jump to Fast-Start Picks →](FAST_START.md)`, `[transparent scoring formula](#our-methodology--scoring-explained)`).
-    *   Some links use file names or paths as text (e.g., `[SCHEMA.md](SCHEMA.md)`), which is generally acceptable for a technical document.
+    *   Most link texts are descriptive and clearly indicate the destination (e.g., `[🚀 Jump to Fast-Start Picks →](../../FAST_START.md)`, `[transparent scoring formula](#our-methodology--scoring-explained)`).
+    *   Some links use file names or paths as text (e.g., `[SCHEMA.md](../SCHEMA.md)`), which is generally acceptable for a technical document.
     *   Critically, some links are just URLs, which are not very descriptive for screen reader users:
         *   Line 280: `[https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)`
         *   Line 282: `[https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)`
@@ -31,7 +31,7 @@
 
 *   **Visual Inspection of Badge Color Contrast:**
     *   Shields.io badges with "brightgreen" background (e.g., coverage, security) typically have good contrast with white text.
-    *   However, custom SVG badges (e.g., `badges/build.svg`, `badges/docs.svg`) require inspection of their internal SVG code or visual rendering to confirm color contrast. This cannot be done with the current tools. If text within these SVGs does not contrast sufficiently with its background, it would be a WCAG failure.
+    *   However, custom SVG badges (e.g., `../../badges/build.svg`, `../../badges/docs.svg`) require inspection of their internal SVG code or visual rendering to confirm color contrast. This cannot be done with the current tools. If text within these SVGs does not contrast sufficiently with its background, it would be a WCAG failure.
 
 *   **Markdown Structure and Keyboard Navigation:**
     *   **Heading Structure**: As noted in a previous structural review, there's an H3 (`### Metrics Explained`) directly following an H1, skipping H2. Consistent heading hierarchy is important for screen reader navigation.
@@ -44,13 +44,13 @@
 
 *   **Alt Text for Images and Badges:**
     *   **(Medium Impact, Low Effort)** Enhance alt text for badges to be more descriptive. For example:
-        *   `![Build status badge](badges/build.svg)`
+        *   `![Build status badge](../../badges/build.svg)`
         *   `![Code coverage: 80%](https://img.shields.io/badge/coverage-80%25-brightgreen)`
         *   `![Security: 0 issues detected](https://img.shields.io/badge/security-0%20issues-brightgreen)`
-        *   `![Documentation status](badges/docs.svg)`
+        *   `![Documentation status](../../badges/docs.svg)`
         *   `![Website status: online](https://img.shields.io/website?down_message=offline&up_message=online&url=https%3A%2F%2Fadrianwedd.github.io%2FAgentic-Index)`
-        *   `![License: MIT](badges/license.svg)` (assuming MIT, update as per actual license badge)
-        *   `![PyPI package version](badges/pypi.svg)`
+        *   `![License: MIT](../../badges/license.svg)` (assuming MIT, update as per actual license badge)
+        *   `![PyPI package version](../../badges/pypi.svg)`
         *   `![Latest GitHub release version](https://img.shields.io/github/release/adrianwedd/Agentic-Index?include_prereleases)`
     *   **(High Impact, Medium Effort - Requires SVG inspection)** For local SVG badges (`badges/*.svg`), ensure that any text within the SVGs has sufficient color contrast with its background (WCAG AA requires 4.5:1 for normal text). This may require editing the SVGs themselves.
 

--- a/docs/readme_review/gaps.md
+++ b/docs/readme_review/gaps.md
@@ -13,7 +13,7 @@
     *   **Overall Use-Case Gap:** The README explains the "what" and "how" of the index creation very well but lacks examples for the "what now?" from a user's perspective wanting to find an AI agent framework.
 
 *   **Link Correctness (Manual Spot Check):**
-    *   **Internal file links** (e.g., `[SCHEMA.md](SCHEMA.md)`, `[docs/METRICS_SCHEMA.md](docs/METRICS_SCHEMA.md)`, `[FAST_START.md](FAST_START.md)`) appear plausible and use correct relative paths based on standard repository structures.
+    *   **Internal file links** (e.g., `[SCHEMA.md](../SCHEMA.md)`, `[docs/METRICS_SCHEMA.md](../METRICS_SCHEMA.md)`, `[FAST_START.md](../../FAST_START.md)`) appear plausible and use correct relative paths based on standard repository structures.
     *   **Internal section links** (e.g., `[📊 Metrics Legend](#metrics-legend)`) correctly use fragment identifiers that correspond to `<a>` tags with `id` attributes within the document.
     *   **External links** (e.g., to `shields.io`, `github.com` for pa11y, `git-lfs.github.com`, `creativecommons.org`, `opensource.org`) seem appropriate and are formatted correctly.
     *   Footnote-style links (e.g., `[1, 2]` in the "Why Agentic Index is Different" section) are numerous and point to `docs/methodology.md`. This is consistent.

--- a/docs/readme_review/structure.md
+++ b/docs/readme_review/structure.md
@@ -48,10 +48,10 @@
 
 *   **Table Content:**
     *   **(Medium Impact, Medium Effort)** The main table "The Agentic-Index Top 100" has empty cells for "Δ Stars" and "Δ Score". If this data is intended to be populated, ensure the scripts do so. If not, consider removing the columns to avoid confusion.
-    *   The table legend within `<details>` is good. Ensure the link `[See full formula →](./docs/methodology.md#scoring-formula)` correctly points to the relevant part of the methodology document.
+    *   The table legend within `<details>` is good. Ensure the link `[See full formula →](../methodology.md#scoring-formula)` correctly points to the relevant part of the methodology document.
 
 *   **Links and Navigation:**
-    *   **(Low Impact, Medium Effort)** Verify all internal links (especially those in the TOC and text) point to the correct sections or documents. The use of relative links like `[🚀 Jump to Fast-Start Picks →](FAST_START.md)` is good.
-    *   The link `[SCHEMA.md](SCHEMA.md)` and `[docs/METRICS_SCHEMA.md](docs/METRICS_SCHEMA.md)` should be checked. Similarly for `[ONBOARDING guide](docs/ONBOARDING.md)`, `[Changelog](./CHANGELOG.md)`, etc.
+    *   **(Low Impact, Medium Effort)** Verify all internal links (especially those in the TOC and text) point to the correct sections or documents. The use of relative links like `[🚀 Jump to Fast-Start Picks →](../../FAST_START.md)` is good.
+    *   The link `[SCHEMA.md](../SCHEMA.md)` and `[docs/METRICS_SCHEMA.md](../METRICS_SCHEMA.md)` should be checked. Similarly for `[ONBOARDING guide](../ONBOARDING.md)`, `[Changelog](../../CHANGELOG.md)`, etc.
 
 Prioritization is based on improving clarity, structure, and completeness for a first-time reader or potential contributor.


### PR DESCRIPTION
## Summary
- fix internal links across `docs/`
- update docs onboarding link
- add instructions for building docs
- ensure site builds without warnings

## Testing
- `mkdocs build`
- `black --check .`
- `isort --check-only .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6852b1234fe4832a9e19c664032a0c01