### PR TITLE
Add README regression tests using allowlist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         name: pytest
         entry: pytest --quiet --cov=agentic_index_cli --cov-fail-under=0
         language: python
-        additional_dependencies: [., pytest, pytest-cov, requests, PyYAML, jsonschema, pydantic, responses, pytest-socket, pytest-env, "typer[all]", matplotlib, fastapi, httpx, aiohttp, rich, click]
+        additional_dependencies: [., pytest, pytest-cov, requests, PyYAML, jsonschema, pydantic, responses, pytest-socket, pytest-env, "typer[all]", matplotlib, fastapi, httpx, aiohttp, rich, click, structlog, jinja2]
         files: \.py$
         exclude: ^scripts/(score_metrics|propagate_pr_tasks)\.py$
       - id: detect-large-files

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -186,3 +186,19 @@ def assert_readme_equivalent(
                     )
             if verbose:
                 print(f"Row {row_idx} {header} ok: {val1} vs {val2} (tol={tol})")
+
+
+def diff_unexpected_lines(diff: str, patterns: list[str]) -> list[str]:
+    """Return diff lines not matching any allowlist pattern."""
+    regexes = [re.compile(p) for p in patterns]
+    bad = []
+    for line in diff.splitlines():
+        if line.startswith(("+++", "---", "@@")):
+            continue
+        if line.startswith("+") or line.startswith("-"):
+            text = line[1:].strip()
+            if not text:
+                continue
+            if not any(r.search(text) for r in regexes):
+                bad.append(line)
+    return bad

--- a/tests/test_readme_regression.py
+++ b/tests/test_readme_regression.py
@@ -1,0 +1,64 @@
+import os
+from pathlib import Path
+
+import agentic_index_cli.internal.inject_readme as inj
+import agentic_index_cli.internal.readme_utils as rutils
+import agentic_index_cli.internal.regression_check as rc
+
+from .helpers import diff_unexpected_lines
+from .test_inject_dry_run import _setup
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ALLOW = rc.load_allowlist(ROOT / "regression_allowlist.yml")
+
+
+def test_current_readme_matches_allowlist(
+    tmp_path, monkeypatch, readme_fixture_path, data_fixture_dir
+):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(
+        rutils.os,
+        "getenv",
+        lambda k, d=None: None if k == "PYTEST_CURRENT_TEST" else os.getenv(k, d),
+    )
+    readme, modified = _setup(
+        tmp_path, monkeypatch, readme_fixture_path, data_fixture_dir
+    )
+    diff = inj.diff(modified, readme)
+    assert diff_unexpected_lines(diff, ALLOW) == []
+
+
+def test_allowlist_filters_allowed_line(
+    tmp_path, monkeypatch, readme_fixture_path, data_fixture_dir
+):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(
+        rutils.os,
+        "getenv",
+        lambda k, d=None: None if k == "PYTEST_CURRENT_TEST" else os.getenv(k, d),
+    )
+    readme, modified = _setup(
+        tmp_path, monkeypatch, readme_fixture_path, data_fixture_dir
+    )
+    readme.write_text(readme.read_text() + "\nagentops\n")
+    diff = inj.diff(modified, readme)
+    assert diff_unexpected_lines(diff, ALLOW) == []
+
+
+def test_unexpected_line_detected(
+    tmp_path, monkeypatch, readme_fixture_path, data_fixture_dir
+):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(
+        rutils.os,
+        "getenv",
+        lambda k, d=None: None if k == "PYTEST_CURRENT_TEST" else os.getenv(k, d),
+    )
+    readme, modified = _setup(
+        tmp_path, monkeypatch, readme_fixture_path, data_fixture_dir
+    )
+    readme.write_text(readme.read_text() + "\nBADLINE\n")
+    diff = inj.diff(modified, readme)
+    bad = diff_unexpected_lines(diff, ALLOW)
+    assert bad and any("BADLINE" in b for b in bad)


### PR DESCRIPTION
## Summary
- check README injection output against a regex allowlist
- extend helper for diff filtering
- include structlog and jinja2 in pre-commit pytest env

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852af2c84d4832aa3682638711d7cca