### PR TITLE
Add CLI and API server tests

### DIFF
--- a/tests/test_api_server_endpoints.py
+++ b/tests/test_api_server_endpoints.py
@@ -1,0 +1,51 @@
+"""Integration tests for agentic_index_api.server."""
+
+import importlib
+import sys
+import types
+
+from fastapi.testclient import TestClient
+
+import agentic_index_api.server as srv
+
+
+def load_app(monkeypatch):
+    monkeypatch.setenv("API_KEY", "k")
+    module = importlib.reload(srv)
+    return TestClient(module.app), module
+
+
+def test_sync_endpoint(monkeypatch, tmp_path):
+    client, mod = load_app(monkeypatch)
+
+    called = {}
+
+    def fake_scrape(min_stars=0, token=None):
+        called["min_stars"] = min_stars
+        return [{"name": "r"}]
+
+    def fake_save(path, repos):
+        called["path"] = path
+        called["repos"] = repos
+
+    monkeypatch.setattr(mod, "scrape", fake_scrape)
+    monkeypatch.setattr(mod, "save_repos", fake_save)
+
+    resp = client.post("/sync", headers={"X-API-KEY": "k"}, json={"min_stars": 1})
+    assert resp.status_code == 200
+    assert resp.json() == {"repos": 1}
+    assert called["min_stars"] == 1
+    assert called["repos"] == [{"name": "r"}]
+
+
+def test_render_endpoint(monkeypatch):
+    client, mod = load_app(monkeypatch)
+
+    called = {}
+    dummy = types.SimpleNamespace(main=lambda: called.setdefault("ran", True))
+    monkeypatch.setitem(sys.modules, "agentic_index_cli.generate_outputs", dummy)
+
+    resp = client.post("/render", headers={"X-API-KEY": "k"})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    assert called.get("ran") is True

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -6,6 +6,7 @@ import agentic_index_cli.enricher as enricher
 import agentic_index_cli.faststart as faststart
 import agentic_index_cli.inject as inject_cli
 import agentic_index_cli.internal.scrape as scrape_mod
+import agentic_index_cli.prune as prune
 import agentic_index_cli.scraper as scraper
 from agentic_index_cli.internal import inject_readme
 
@@ -122,3 +123,19 @@ def test_plot_trends_cli(capsys):
     plot_trends.main()
     captured = capsys.readouterr()
     assert "not yet implemented" in captured.out
+
+
+def test_prune_cli(monkeypatch):
+    called = {}
+
+    def fake_prune(
+        inactive, repos_path=Path("repos.json"), changelog_path=Path("CHANGELOG.md")
+    ):
+        called["args"] = (inactive, repos_path, changelog_path)
+
+    monkeypatch.setattr(prune, "prune", fake_prune)
+    prune.main(
+        ["--inactive", "10", "--repos-path", "r.json", "--changelog-path", "c.md"]
+    )
+
+    assert called["args"] == (10, Path("r.json"), Path("c.md"))

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -2,6 +2,9 @@ from pathlib import Path
 
 import agentic_index_cli.__main__ as main
 import agentic_index_cli.cli as ai
+import agentic_index_cli.enricher as enricher
+import agentic_index_cli.faststart as faststart
+import agentic_index_cli.prune as prune
 
 
 def test_main_scrape(monkeypatch, tmp_path):
@@ -15,3 +18,57 @@ def test_main_scrape(monkeypatch, tmp_path):
         ["scrape", "--min-stars", "1", "--iterations", "2", "--output", str(tmp_path)]
     )
     assert called["args"] == (1, 2, Path(tmp_path))
+
+
+def _patch_common(monkeypatch):
+    monkeypatch.setattr(main, "configure_logging", lambda *a, **k: None)
+    monkeypatch.setattr(main, "configure_sentry", lambda *a, **k: None)
+
+
+def test_main_enrich(monkeypatch):
+    _patch_common(monkeypatch)
+    called = {}
+
+    def fake_enrich(args):
+        called["args"] = args
+
+    monkeypatch.setattr(enricher, "main", fake_enrich)
+    main.main(["enrich", "repos.json"])
+
+    assert called["args"] == ["repos.json"]
+
+
+def test_main_faststart(monkeypatch):
+    _patch_common(monkeypatch)
+    called = {}
+
+    def fake_run(top, path):
+        called["args"] = (top, path)
+
+    monkeypatch.setattr(faststart, "run", fake_run)
+    main.main(["faststart-cmd", "--top", "3", "data.json"])
+
+    assert called["args"] == (3, Path("data.json"))
+
+
+def test_main_prune(monkeypatch):
+    _patch_common(monkeypatch)
+    called = {}
+
+    def fake_prune(inactive, repos_path, changelog_path):
+        called["args"] = (inactive, repos_path, changelog_path)
+
+    monkeypatch.setattr(prune, "prune", fake_prune)
+    main.main(
+        [
+            "prune-cmd",
+            "--inactive",
+            "30",
+            "--repos-path",
+            "r.json",
+            "--changelog-path",
+            "CHANGELOG.md",
+        ]
+    )
+
+    assert called["args"] == (30, Path("r.json"), Path("CHANGELOG.md"))


### PR DESCRIPTION
## Summary
- add CLI entrypoint coverage in tests
- extend CLI command tests for prune
- add integration tests for sync and render endpoints

Closes #??

------
https://chatgpt.com/codex/tasks/task_e_6853a0bcd1b8832aa556597788db9c21