### PR TITLE
Default CI_OFFLINE in setup script

### DIFF
--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -46,6 +46,10 @@ pre-commit install --install-hooks
 
 export PYTHONPATH="$PWD"
 
+# Enable offline mode for tests by default
+: "${CI_OFFLINE:=1}"
+export CI_OFFLINE
+
 if [[ -f .env ]]; then
   echo "Loading environment variables from .env"
   set -o allexport


### PR DESCRIPTION
## Summary
- ensure `scripts/setup-env.sh` sets `CI_OFFLINE` by default

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q` *(fails: tests/test_api_server_endpoints.py::test_sync_endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_6853e0e6b3e0832a91576a2b9d06170f