### PR TITLE
Enable dark mode for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install docs dependencies
         run: pip install -r docs/requirements.txt
       - name: Install dependencies
-        run: pip install mkdocs-material mkdocstrings[python] sphinx sphinx_rtd_theme
+        run: pip install mkdocs-material mkdocstrings[python] sphinx furo
       - name: Build MkDocs site
         run: mkdocs build --strict
       - name: Build Sphinx docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
+furo
 pydantic
 rich

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "Agentic Index"
 author = "OpenAI"
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 autodoc_typehints = "description"
 autodoc_mock_imports = ["pydantic"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,15 @@
 site_name: Agentic Index
-theme: material
+theme:
+  name: material
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
 plugins:
   - search
   - mkdocstrings

--- a/scripts/funky_demo.py
+++ b/scripts/funky_demo.py
@@ -11,7 +11,6 @@ rendered with :mod:`rich` for a deluxe terminal experience.
 from __future__ import annotations
 
 import json
-
 import os
 import shutil
 import subprocess
@@ -97,7 +96,6 @@ def main() -> None:
     show_doc(rank.main)
     show_doc(inj.main)
 
-
     inj.REPOS_PATH = data_dir / "repos.json"
     inj.DATA_PATH = data_dir / "top100.md"
     inj.SNAPSHOT = data_dir / "last_snapshot.json"
@@ -134,7 +132,6 @@ def main() -> None:
 
     console.rule("smoke test")
     run(["bash", "scripts/e2e_test.sh"])
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- format funky_demo
- allow dark theme toggle in MkDocs
- use Furo for Sphinx docs
- install Furo in docs workflow

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855f95a5858832aad2d43d2eb82ad24