### PR TITLE
Fix pipeline scripts and workflows

### DIFF
--- a/.github/workflows/inject-readme.yml
+++ b/.github/workflows/inject-readme.yml
@@ -33,12 +33,12 @@ jobs:
           pip install -r requirements.txt
           pip install -e '.[dev]'
       - name: Run README Injection
-        run: python -m agentic_index_cli.internal.inject_readme --all
+        run: python -m agentic_index_cli.internal.inject_readme --all-categories
       - name: Commit & Push Changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md
+          git add README.md README_*.md
           if ! git diff --quiet; then
             git commit -m "chore: daily README table update"
             git push

--- a/.github/workflows/rank.yml
+++ b/.github/workflows/rank.yml
@@ -29,8 +29,7 @@ jobs:
       - name: Run ranker
         run: |
           echo "running ranker" | tee rank.log
-          # Placeholder for ranking logic generating repos.json
-          python scripts/ranker.py >> rank.log 2>&1
+          python -m agentic_index_cli.ranker data/repos.json >> rank.log 2>&1
       - name: Validate JSON
         run: |
           python -m json.tool data/repos.json > /dev/null

--- a/agentic_index_cli/internal/inject_readme.py
+++ b/agentic_index_cli/internal/inject_readme.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 import time
 import uuid
+from pathlib import Path
 
 import structlog
 
@@ -37,24 +38,37 @@ from .readme_utils import (
 )
 
 
-def _load_rows(*args, **kwargs):
-    """Proxy to ``readme_utils._load_rows`` using module paths."""
+def _load_rows(
+    *args, repos_path: Path | None = None, ranked_path: Path | None = None, **kwargs
+):
+    """Proxy to ``readme_utils._load_rows`` using provided paths."""
+    if repos_path is None:
+        repos_path = REPOS_PATH
+    if ranked_path is None:
+        ranked_path = RANKED_PATH
     return _readme_utils._load_rows(
         *args,
-        repos_path=REPOS_PATH,
-        ranked_path=RANKED_PATH,
+        repos_path=repos_path,
+        ranked_path=ranked_path,
         **kwargs,
     )
 
 
-def build_readme(*args, **kwargs):
-    """Proxy ``readme_utils.build_readme`` using module paths."""
+def build_readme(
+    *args,
+    repos_path: Path | None = None,
+    ranked_path: Path | None = None,
+    readme_path: Path | None = None,
+    index_path: Path | None = None,
+    **kwargs,
+) -> str:
+    """Proxy ``readme_utils.build_readme`` using specified paths."""
     return _build_readme(
         *args,
-        readme_path=README_PATH,
-        repos_path=REPOS_PATH,
-        ranked_path=RANKED_PATH,
-        index_path=BY_CAT_INDEX,
+        readme_path=README_PATH if readme_path is None else readme_path,
+        repos_path=REPOS_PATH if repos_path is None else repos_path,
+        ranked_path=RANKED_PATH if ranked_path is None else ranked_path,
+        index_path=BY_CAT_INDEX if index_path is None else index_path,
         **kwargs,
     )
 
@@ -71,19 +85,39 @@ def main(
     sort_by: str = DEFAULT_SORT_FIELD,
     top_n: int = DEFAULT_TOP_N,
     limit: int | None = None,
+    repos_path: Path | None = None,
+    ranked_path: Path | None = None,
+    readme_path: Path | None = None,
+    index_path: Path | None = None,
 ) -> int:
     """Synchronise the README table."""
     request_id = str(uuid.uuid4())
     log = logger.bind(func="main", request_id=request_id)
     start_time = time.perf_counter()
-    for path in (DATA_PATH, REPOS_PATH, SNAPSHOT, BY_CAT_INDEX):
+    if repos_path is None:
+        repos_path = REPOS_PATH
+    if ranked_path is None:
+        ranked_path = RANKED_PATH
+    if readme_path is None:
+        readme_path = README_PATH
+    if index_path is None:
+        index_path = BY_CAT_INDEX
+    for path in (DATA_PATH, repos_path, SNAPSHOT, index_path):
         if not path.exists():
             raise FileNotFoundError(str(path))
-    if not (RANKED_PATH.exists() or REPOS_PATH.exists()):
-        raise FileNotFoundError(str(REPOS_PATH))
+    if not (ranked_path.exists() or repos_path.exists()):
+        raise FileNotFoundError(str(repos_path))
     try:
         row_limit = top_n if limit is None else limit
-        new_text = build_readme(sort_by=sort_by, limit=row_limit, top_n=top_n)
+        new_text = build_readme(
+            sort_by=sort_by,
+            limit=row_limit,
+            top_n=top_n,
+            repos_path=repos_path,
+            ranked_path=ranked_path,
+            readme_path=readme_path,
+            index_path=index_path,
+        )
     except Exception as exc:
         log.exception("build-failed", error=str(exc))
         return 1
@@ -92,18 +126,18 @@ def main(
         if not SNAPSHOT.exists():
             print(f"Warning: missing snapshot {SNAPSHOT}", file=sys.stderr)
             return 0
-        if diff(new_text, README_PATH):
+        if diff(new_text, readme_path):
             print("README.md is out of date", file=sys.stderr)
             return 1
         return 0
 
     if dry_run:
-        print(diff(new_text, README_PATH))
+        print(diff(new_text, readme_path))
         return 0
 
-    if write and (force or diff(new_text, README_PATH)):
+    if write and (force or diff(new_text, readme_path)):
         try:
-            README_PATH.write_text(new_text, encoding="utf-8")
+            readme_path.write_text(new_text, encoding="utf-8")
         except Exception as exc:
             log.exception("write-error", error=str(exc))
             raise
@@ -121,18 +155,27 @@ def write_category_readme(
     sort_by: str = DEFAULT_SORT_FIELD,
     top_n: int = DEFAULT_TOP_N,
     limit: int | None = None,
+    repos_path: Path | None = None,
+    ranked_path: Path | None = None,
 ) -> int:
     """Write or check ``README_<category>.md``."""
     request_id = str(uuid.uuid4())
     log = logger.bind(func="write_category_readme", request_id=request_id)
     start_time = time.perf_counter()
     cfg_limit = top_n if limit is None else limit
+    if repos_path is None:
+        repos_path = REPOS_PATH
+    if ranked_path is None:
+        ranked_path = RANKED_PATH
+    for p in (repos_path,):
+        if not p.exists():
+            raise FileNotFoundError(str(p))
     text = build_category_table(
         category,
         sort_by=sort_by,
         limit=cfg_limit,
-        repos_path=REPOS_PATH,
-        ranked_path=RANKED_PATH,
+        repos_path=repos_path,
+        ranked_path=ranked_path,
     )
     fname = f"README_{category.replace(' ', '_')}.md"
     path = ROOT / fname
@@ -149,14 +192,25 @@ def write_category_readme(
     return 0
 
 
-def write_all_categories(**kwargs) -> int:
+def write_all_categories(
+    *, repos_path: Path | None = None, ranked_path: Path | None = None, **kwargs
+) -> int:
     """Write or check README files for all categories."""
     request_id = str(uuid.uuid4())
     log = logger.bind(func="write_all_categories", request_id=request_id)
     start_time = time.perf_counter()
+    if repos_path is None:
+        repos_path = REPOS_PATH
+    if ranked_path is None:
+        ranked_path = RANKED_PATH
     status = 0
-    for cat in available_categories(REPOS_PATH, RANKED_PATH):
-        ret = write_category_readme(cat, **kwargs)
+    for cat in available_categories(repos_path, ranked_path):
+        ret = write_category_readme(
+            cat,
+            repos_path=repos_path,
+            ranked_path=ranked_path,
+            **kwargs,
+        )
         status = max(status, ret)
     log.info("write-all-complete", duration=time.perf_counter() - start_time)
     return status

--- a/agentic_index_cli/internal/rank_main.py
+++ b/agentic_index_cli/internal/rank_main.py
@@ -105,6 +105,8 @@ def main(json_path: str = "data/repos.json", *, config: dict | None = None) -> N
         save_repos(data_file, repos)
         persist_history(data_file, repos, delta_days=delta_days)
         write_by_category(data_dir, repos)
+        ranked_path = data_dir / "ranked.json"
+        save_repos(ranked_path, repos)
 
     header = [
         "| Rank | Repo | Description | Score | Stars | Δ Stars |",

--- a/scripts/inject_readme.py
+++ b/scripts/inject_readme.py
@@ -50,6 +50,8 @@ if __name__ == "__main__":
     )
     parser.add_argument("--top-n", type=int, default=DEFAULT_TOP_N)
     parser.add_argument("--limit", type=int, help="Maximum rows to render")
+    parser.add_argument("--repos-path", type=Path, help="Path to repos.json")
+    parser.add_argument("--ranked-path", type=Path, help="Path to ranked.json")
     cat_group = parser.add_mutually_exclusive_group()
     cat_group.add_argument("--category", help="Generate README for one category")
     cat_group.add_argument(
@@ -61,32 +63,20 @@ if __name__ == "__main__":
 
     check = args.check or args.dry_run
     write = args.write or not check
+    kwargs = {
+        "force": args.force,
+        "check": check,
+        "write": write,
+        "sort_by": args.sort_by,
+        "top_n": args.top_n,
+        "limit": args.limit,
+        "repos_path": args.repos_path,
+        "ranked_path": args.ranked_path,
+    }
     if args.category or args.all_categories:
         if args.all_categories:
-            write_all_categories(
-                force=args.force,
-                check=check,
-                write=write,
-                sort_by=args.sort_by,
-                top_n=args.top_n,
-                limit=args.limit,
-            )
+            write_all_categories(**kwargs)
         else:
-            write_category_readme(
-                args.category,
-                force=args.force,
-                check=check,
-                write=write,
-                sort_by=args.sort_by,
-                top_n=args.top_n,
-                limit=args.limit,
-            )
+            write_category_readme(args.category, **kwargs)
     else:
-        main(
-            force=args.force,
-            check=check,
-            write=write,
-            sort_by=args.sort_by,
-            top_n=args.top_n,
-            limit=args.limit,
-        )
+        main(**kwargs)

--- a/scripts/refresh_category.py
+++ b/scripts/refresh_category.py
@@ -40,8 +40,7 @@ def refresh(category: str, out_dir: Path) -> None:
     rank(str(data_path))
 
     by_cat = out_dir / "by_category"
-    inj.REPOS_PATH = data_path
-    inj.write_category_readme(category, force=True)
+    inj.write_category_readme(category, force=True, repos_path=data_path)
 
     index_file = by_cat / "index.json"
     try:

--- a/tests/test_inject_cli_script.py
+++ b/tests/test_inject_cli_script.py
@@ -10,18 +10,41 @@ def test_inject_script_check(monkeypatch, tmp_path):
         force=False,
         check=False,
         write=True,
+        dry_run=False,
         sort_by="score",
         top_n=100,
         limit=None,
+        repos_path=None,
+        ranked_path=None,
+        readme_path=None,
+        index_path=None,
     ):
-        calls["args"] = (force, check, write, sort_by, top_n, limit)
+        calls["args"] = (
+            force,
+            check,
+            write,
+            sort_by,
+            top_n,
+            limit,
+            repos_path,
+            ranked_path,
+        )
         return 0
 
     monkeypatch.setattr("agentic_index_cli.internal.inject_readme.main", fake_main)
     script = Path(__file__).resolve().parents[1] / "scripts" / "inject_readme.py"
     sys.argv = [str(script), "--check"]
     runpy.run_path(script, run_name="__main__")
-    assert calls["args"] == (False, True, False, "score", 100, None)
+    assert calls["args"] == (
+        False,
+        True,
+        False,
+        "score",
+        100,
+        None,
+        None,
+        None,
+    )
 
 
 def test_inject_script_category(monkeypatch):

--- a/tests/test_ranked_output.py
+++ b/tests/test_ranked_output.py
@@ -1,0 +1,29 @@
+import json
+import os
+from pathlib import Path
+
+import agentic_index_cli.internal.rank_main as rank_mod
+
+
+def test_rank_writes_ranked_json(tmp_path):
+    repos = [
+        {
+            "name": "a",
+            "full_name": "o/a",
+            "stargazers_count": 10,
+            "forks_count": 0,
+            "open_issues_count": 0,
+            "pushed_at": "2025-01-01T00:00:00Z",
+            "owner": {"login": "o"},
+            "license": {"spdx_id": "MIT"},
+        }
+    ]
+    repo_file = tmp_path / "repos.json"
+    repo_file.write_text(json.dumps({"schema_version": 1, "repos": repos}))
+    os.environ["PYTEST_CURRENT_TEST"] = "1"
+    rank_mod.main(str(repo_file))
+    ranked_file = tmp_path / "ranked.json"
+    assert ranked_file.exists()
+    data = json.loads(ranked_file.read_text())
+    assert isinstance(data.get("repos"), list)
+    assert data["repos"][0]["name"] == "a"


### PR DESCRIPTION
## Summary
- extend inject_readme CLI with custom data paths
- persist ranked.json when ranking
- ensure workflow commits all README files
- add regression test for ranked.json output

## Testing
- `black --check . && isort --check-only .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68593911c384832a95e1a15ae909764f