### PR TITLE
Fix E2E test script

### DIFF
--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -9,9 +9,10 @@ ARTIFACTS=$(mktemp -d e2e_demo_XXXX)
 DATA_DIR="$ARTIFACTS/data"
 mkdir -p "$DATA_DIR/by_category"
 
-# Seed with fixture repos
+# Seed with fixture repos and README
 cp tests/fixtures/data/repos.json "$DATA_DIR/repos.json"
 printf '[]' > "$DATA_DIR/last_snapshot.json"
+cp tests/snapshots/README.md "$ARTIFACTS/README.md"
 touch "$DATA_DIR/top100.md"
 printf '{}' > "$DATA_DIR/by_category/index.json"
 
@@ -19,12 +20,30 @@ export PYTHONPATH="$ROOT"
 
 python -m agentic_index_cli.enricher "$DATA_DIR/repos.json"
 python -m agentic_index_cli.internal.rank_main "$DATA_DIR/repos.json"
-python -m agentic_index_cli.internal.inject_readme \
-  --force --top-n 5 --limit 5 \
-  --repos "$DATA_DIR/repos.json" \
-  --data "$DATA_DIR/top100.md" \
-  --snapshot "$DATA_DIR/last_snapshot.json" \
-  --index "$DATA_DIR/by_category/index.json" \
-  --readme "$ARTIFACTS/README.md"
+python - "$DATA_DIR" "$ARTIFACTS/README.md" <<'EOF'
+import sys
+from pathlib import Path
+import agentic_index_cli.internal.readme_utils as ru
+from agentic_index_cli.internal.inject_readme import build_readme
+
+data_dir = Path(sys.argv[1])
+readme_path = Path(sys.argv[2])
+
+ru.DATA_PATH = data_dir / "top100.md"
+ru.REPOS_PATH = data_dir / "repos.json"
+ru.RANKED_PATH = data_dir / "ranked.json"
+ru.SNAPSHOT = data_dir / "last_snapshot.json"
+ru.BY_CAT_INDEX = data_dir / "by_category/index.json"
+
+text = build_readme(
+    limit=5,
+    top_n=50,
+    readme_path=readme_path,
+    repos_path=ru.REPOS_PATH,
+    ranked_path=ru.RANKED_PATH,
+    index_path=ru.BY_CAT_INDEX,
+)
+readme_path.write_text(text, encoding="utf-8")
+EOF
 
 echo "E2E test complete. Artifacts in $ARTIFACTS"

--- a/tasks.yml
+++ b/tasks.yml
@@ -96,7 +96,7 @@
   component: tests
   dependencies: []
   priority: 1
-  status: todo
+  status: done
 - id: 5
   description: Add a GitHub Actions job to run the end-to-end smoke test on pull requests
   component: ci


### PR DESCRIPTION
## Summary
- generate README artifact correctly in `scripts/e2e_test.sh`
- mark task 4 as done

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`
- `bash scripts/e2e_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_685942fde82c832aa026dc02e7996d18