### PR TITLE
Add rollback doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,8 @@ bash scripts/trigger_refresh.sh 75
 Replace `75` with your desired minimum star count. The script requires the GitHub CLI and an authenticated token.
 Set a personal access token via the `GITHUB_TOKEN_REPO_STATS` environment variable to avoid hitting rate limits when scraping.
 
+If a pipeline step fails and leaves corrupted data, see [ROLLBACK.md](docs/ROLLBACK.md) for how to revert the GitHub state and clear local caches before re-running.
+
 ### 📝 Forcing README injection
 
 The injector normally skips writing `README.md` when no changes are detected. Use `--force` to rewrite the table regardless:

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -1,0 +1,28 @@
+# Rolling Back a Failed Pipeline
+
+If a refresh step corrupts `data/repos.json` or other generated files, follow these steps to restore a known-good state.
+
+## Reverting GitHub Data
+
+1. Identify the last healthy commit in the repository history.
+2. Revert the faulty commit or reset the branch:
+   ```bash
+   git checkout main
+   git revert <bad-commit-sha>
+   # or
+   git reset --hard <good-commit-sha>
+   git push --force-with-lease
+   ```
+   You can also use GitHub's "Revert" button on the merge commit if the change was merged via pull request.
+3. Verify that `data/repos.json` and related artifacts match the previous version.
+
+## Cleaning Local Caches
+
+Stale files may live under `.cache/` and `data/`. Remove them before re-running the pipeline:
+
+```bash
+rm -rf .cache
+rm -f data/*.json data/*.md
+```
+
+Re-run the pipeline from the first step to regenerate fresh data.

--- a/tasks.yml
+++ b/tasks.yml
@@ -110,5 +110,5 @@
   dependencies:
     - 4
   priority: 3
-  status: todo
+  status: done
 

--- a/tests/fixtures/README_fixture.md
+++ b/tests/fixtures/README_fixture.md
@@ -340,6 +340,8 @@ bash scripts/trigger_refresh.sh 75
 Replace `75` with your desired minimum star count. The script requires the GitHub CLI and an authenticated token.
 Set a personal access token via the `GITHUB_TOKEN_REPO_STATS` environment variable to avoid hitting rate limits when scraping.
 
+If a pipeline step fails and leaves corrupted data, see [ROLLBACK.md](docs/ROLLBACK.md) for how to revert the GitHub state and clear local caches before re-running.
+
 ### 📝 Forcing README injection
 
 The injector normally skips writing `README.md` when no changes are detected. Use `--force` to rewrite the table regardless:


### PR DESCRIPTION
## Summary
- document how to recover if a pipeline step corrupts data
- link rollback guide from README
- update README fixture
- mark task 6 done in tasks.yml

## Testing
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595a5838e0832a98b0b8ef5da59b6b