### PR TITLE
Improve coverage gate logic

### DIFF
--- a/scripts/coverage_gate.py
+++ b/scripts/coverage_gate.py
@@ -1,12 +1,28 @@
 """Fail CI if coverage falls below a set threshold."""
 
+import os
+import re
 import sys
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 THRESHOLD = 80  # updated threshold for core logic tests
 
 
-def main(path: str = "coverage.xml") -> int:
+def _update_threshold(new_value: int, file_path: str) -> None:
+    """Replace ``THRESHOLD`` assignment in ``file_path`` with ``new_value``."""
+    path = Path(file_path)
+    text = path.read_text()
+    pattern = r"^(THRESHOLD\s*=\s*)\d+"
+    new_text, count = re.subn(pattern, rf"\g<1>{new_value}", text, flags=re.M)
+    if count != 1:
+        raise ValueError("THRESHOLD constant not found")
+    path.write_text(new_text)
+
+
+def main(
+    path: str = "coverage.xml", *, bump: bool = False, script_path: str | None = None
+) -> int:
     """Return exit code ``1`` if coverage is below ``THRESHOLD``."""
     tree = ET.parse(path)
     rate = float(tree.getroot().attrib.get("line-rate", 0)) * 100
@@ -16,9 +32,23 @@ def main(path: str = "coverage.xml") -> int:
         print("Coverage below threshold. Add tests or adjust THRESHOLD.")
         return 1
     if percent > THRESHOLD + 5 and THRESHOLD < 90:
-        print("TODO: coverage increased; consider raising THRESHOLD")
+        new_threshold = min(90, (percent // 5) * 5)
+        if bump or os.getenv("BUMP_THRESHOLD"):
+            target = script_path or __file__
+            _update_threshold(new_threshold, target)
+            print(f"Bumped THRESHOLD to {new_threshold}%")
+        else:
+            print(
+                f"Coverage increased; run with --bump to raise THRESHOLD to {new_threshold}%"
+            )
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "coverage.xml"))
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", nargs="?", default="coverage.xml")
+    parser.add_argument("--bump", action="store_true")
+    args = parser.parse_args()
+    sys.exit(main(args.path, bump=args.bump))

--- a/tests/test_coverage_gate.py
+++ b/tests/test_coverage_gate.py
@@ -17,3 +17,29 @@ def test_gate_pass(tmp_path):
 def test_gate_fail(tmp_path):
     xml = _write_xml(tmp_path, 0.79)
     assert main(str(xml)) == 1
+
+
+def _copy_script(tmp_path: Path) -> Path:
+    src = Path("scripts/coverage_gate.py")
+    dest = tmp_path / "coverage_gate.py"
+    dest.write_text(src.read_text())
+    return dest
+
+
+def test_high_coverage_instruction(tmp_path, capsys):
+    xml = _write_xml(tmp_path, 0.87)
+    script = _copy_script(tmp_path)
+    assert main(str(xml), script_path=str(script)) == 0
+    out = capsys.readouterr().out
+    assert "run with --bump" in out
+    assert "Bumped THRESHOLD" not in out
+    assert "THRESHOLD = 80" in script.read_text()
+
+
+def test_high_coverage_bump(tmp_path, capsys):
+    xml = _write_xml(tmp_path, 0.87)
+    script = _copy_script(tmp_path)
+    assert main(str(xml), bump=True, script_path=str(script)) == 0
+    out = capsys.readouterr().out
+    assert "Bumped THRESHOLD to 85%" in out
+    assert "THRESHOLD = 85" in script.read_text()


### PR DESCRIPTION
## Summary
- update coverage_gate to allow automatic THRESHOLD bumps
- add tests for bumping logic and instruction message

## Testing
- `source scripts/setup-env.sh`
- `black --check .`
- `isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595da3eb60832a9dac302bf2dc7e6a