### PR TITLE
Centralize SCORE_KEY constant

### DIFF
--- a/agentic_index_cli/cli.py
+++ b/agentic_index_cli/cli.py
@@ -10,9 +10,10 @@ from typing import Dict, List
 
 from rich.progress import track
 
+from agentic_index_cli.constants import SCORE_KEY
+
 from .network import search_and_harvest
 from .render import changelog, load_previous, save_changelog, save_csv, save_markdown
-from .scoring import SCORE_KEY
 
 
 def sort_and_select(repos: List[Dict], limit: int = 100) -> List[Dict]:

--- a/agentic_index_cli/constants.py
+++ b/agentic_index_cli/constants.py
@@ -1,0 +1,1 @@
+SCORE_KEY = "AgenticIndexScore"

--- a/agentic_index_cli/internal/rank.py
+++ b/agentic_index_cli/internal/rank.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import lib.quality_metrics  # ensure built-in metrics are registered
 from agentic_index_cli.config import load_config
+from agentic_index_cli.constants import SCORE_KEY
 from agentic_index_cli.scoring import (
     compute_issue_health,
     compute_recency_factor,
@@ -24,8 +25,6 @@ from agentic_index_cli.validate import load_repos, save_repos
 from lib.metrics_registry import get_metrics
 
 # ─────────────────────────  Scoring & categorisation  ──────────────────────────
-
-SCORE_KEY = "AgenticIndexScore"
 
 
 def compute_score(repo: dict) -> float:

--- a/agentic_index_cli/internal/rank_main.py
+++ b/agentic_index_cli/internal/rank_main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import lib.quality_metrics  # ensure built-in metrics are registered
 from agentic_index_cli.config import load_config
+from agentic_index_cli.constants import SCORE_KEY
 from agentic_index_cli.scoring import (
     compute_issue_health,
     compute_recency_factor,
@@ -16,7 +17,7 @@ from agentic_index_cli.templates import SUMMARY_ROW_TMPL, format_link, short_des
 from agentic_index_cli.validate import load_repos, save_repos
 
 from .badges import generate_badges
-from .scoring import SCORE_KEY, compute_score
+from .scoring import compute_score
 from .scoring import infer_category as _infer_category
 from .snapshot import persist_history, write_by_category
 

--- a/agentic_index_cli/internal/scoring.py
+++ b/agentic_index_cli/internal/scoring.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
+from agentic_index_cli.constants import SCORE_KEY
 from lib.metrics_registry import get_metrics
-
-SCORE_KEY = "AgenticIndexScore"
 
 
 def compute_score(repo: dict) -> float:

--- a/agentic_index_cli/internal/snapshot.py
+++ b/agentic_index_cli/internal/snapshot.py
@@ -5,9 +5,8 @@ import json
 import shutil
 from pathlib import Path
 
+from agentic_index_cli.constants import SCORE_KEY
 from agentic_index_cli.validate import save_repos
-
-from .scoring import SCORE_KEY
 
 __all__ = ["persist_history", "write_by_category"]
 

--- a/agentic_index_cli/network.py
+++ b/agentic_index_cli/network.py
@@ -13,9 +13,10 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 import structlog
 
+from .constants import SCORE_KEY
 from .exceptions import APIError
 from .internal import http_utils
-from .scoring import SCORE_KEY, categorize, compute_score
+from .scoring import categorize, compute_score
 
 logger = structlog.get_logger(__name__).bind(file=__file__)
 

--- a/agentic_index_cli/render.py
+++ b/agentic_index_cli/render.py
@@ -8,7 +8,7 @@ from typing import Dict, List
 
 from jinja2 import Template
 
-from .scoring import SCORE_KEY
+from agentic_index_cli.constants import SCORE_KEY
 
 
 def save_csv(repos: List[Dict], path: Path) -> None:

--- a/agentic_index_cli/scoring.py
+++ b/agentic_index_cli/scoring.py
@@ -10,9 +10,9 @@ from typing import Dict, List, Optional
 
 import structlog
 
-logger = structlog.get_logger(__name__).bind(file=__file__)
+from agentic_index_cli.constants import SCORE_KEY
 
-SCORE_KEY = "AgenticIndexScore"
+logger = structlog.get_logger(__name__).bind(file=__file__)
 
 PERMISSIVE_LICENSES = {
     "mit",


### PR DESCRIPTION
## Summary
- define a shared SCORE_KEY in `agentic_index_cli.constants`
- import this constant across CLI modules

## Testing
- `black --check agentic_index_cli/constants.py agentic_index_cli/network.py agentic_index_cli/cli.py agentic_index_cli/internal/snapshot.py agentic_index_cli/internal/scoring.py agentic_index_cli/internal/rank_main.py agentic_index_cli/internal/rank.py agentic_index_cli/render.py agentic_index_cli/scoring.py`
- `isort --check-only agentic_index_cli/constants.py agentic_index_cli/network.py agentic_index_cli/cli.py agentic_index_cli/internal/snapshot.py agentic_index_cli/internal/scoring.py agentic_index_cli/internal/rank_main.py agentic_index_cli/internal/rank.py agentic_index_cli/render.py agentic_index_cli/scoring.py`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68624e5a1564832a8300e40f1c52a43d