### PR TITLE
Fix detect_large_files pre-commit import

### DIFF
--- a/scripts/detect_large_files.py
+++ b/scripts/detect_large_files.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Invoke ``check_added_large_files`` via ``pre-commit``."""
 
-from pre_commit_hooks.check_added_large_files import main
-
 if __name__ == "__main__":
+    from pre_commit_hooks.check_added_large_files import main
+
     raise SystemExit(main())


### PR DESCRIPTION
## Summary
- avoid import-time failure in `detect_large_files` hook

## Testing
- `PYTHONPATH="$PWD" pytest -q`
- `black --check . && isort --check-only .`


------
https://chatgpt.com/codex/tasks/task_e_686253f183cc832a8cc3ca0e37496b72