### PR TITLE
Add Settings validation for server

### DIFF
--- a/agentic_index_api/config.py
+++ b/agentic_index_api/config.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Configuration for the API server loaded from environment variables."""
+
+    API_KEY: str
+    IP_WHITELIST: str
+
+    @property
+    def whitelist(self) -> set[str]:
+        """Return ``IP_WHITELIST`` as a normalized set of addresses."""
+        return {ip.strip() for ip in self.IP_WHITELIST.split(",") if ip.strip()}
+
+    class Config:
+        case_sensitive = True
+        env_prefix = ""

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -3,18 +3,13 @@ import importlib
 import pytest
 from fastapi.testclient import TestClient
 
-import agentic_index_api.server as srv
 
+def load_app(monkeypatch, key="k", ips=""):
+    """Reload the server with the given environment variables."""
+    monkeypatch.setenv("API_KEY", key)
+    monkeypatch.setenv("IP_WHITELIST", ips)
+    import agentic_index_api.server as srv
 
-def load_app(monkeypatch, key=None, ips=None):
-    if key is not None:
-        monkeypatch.setenv("API_KEY", key)
-    else:
-        monkeypatch.delenv("API_KEY", raising=False)
-    if ips is not None:
-        monkeypatch.setenv("IP_WHITELIST", ips)
-    else:
-        monkeypatch.delenv("IP_WHITELIST", raising=False)
     module = importlib.reload(srv)
     return module.app, module
 

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,16 +1,18 @@
 from fastapi.testclient import TestClient
 
-from agentic_index_api.server import app
+from .test_api_auth import load_app
 
 
-def test_status():
+def test_status(monkeypatch):
+    app, _ = load_app(monkeypatch)
     client = TestClient(app)
     resp = client.get("/status")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
 
 
-def test_healthz():
+def test_healthz(monkeypatch):
+    app, _ = load_app(monkeypatch)
     client = TestClient(app)
     resp = client.get("/healthz")
     assert resp.status_code == 200

--- a/tests/test_api_server_endpoints.py
+++ b/tests/test_api_server_endpoints.py
@@ -6,11 +6,12 @@ import types
 
 from fastapi.testclient import TestClient
 
-import agentic_index_api.server as srv
-
 
 def load_app(monkeypatch):
     monkeypatch.setenv("API_KEY", "k")
+    monkeypatch.setenv("IP_WHITELIST", "")
+    import agentic_index_api.server as srv
+
     module = importlib.reload(srv)
     return TestClient(module.app), module
 


### PR DESCRIPTION
## Summary
- add `Settings` model using `pydantic-settings`
- validate env vars on server startup
- switch server auth to use settings object
- update server tests for new configuration handling

## Testing
- `black --check . && isort --check-only .`
- `PYTHONPATH="$PWD" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e0b43d6c8832a8bbda98b11b7c032