### PR TITLE
Add Claude Code Action workflow

### DIFF
--- a/.github/workflows/claude-code-action.yml
+++ b/.github/workflows/claude-code-action.yml
@@ -1,0 +1,16 @@
+name: Claude Code Action
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened, reopened, synchronize]
+jobs:
+  run-claude:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Claude Code Action Official
+        uses: anthropics/claude-code-action@beta
+

--- a/agents.md
+++ b/agents.md
@@ -19,6 +19,7 @@ Agentic Index curates & ranks AI-agent repos so developers can quickly find reli
 | SafeRebase | comment /rebase | `.github/actions/safe-rebase/action.yml` | Rebase PR into new branch | draft <orig>-rebased PR |
 | IssueLogger | manual / CI | `agentic_index_cli/issue_logger.py` | Post GitHub issues/comments | Issue/Comment URLs |
 | APIServer | container | `agentic_index_api/server.py` | HTTP interface | JSON responses |
+| Claude Code Action Official | pull_request, issues | `.github/workflows/claude-code-action.yml` | Answer questions and implement code changes | PR/issue comments |
 
 
 Add any new agents as you implement them.*


### PR DESCRIPTION
## Summary
- add a workflow running `anthropics/claude-code-action@beta`
- document the agent in `agents.md`

## Testing
- `black --check .`
- `isort --check-only .`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68807438d070832a836c70eaf920cdf9